### PR TITLE
Responsive tables adjustments

### DIFF
--- a/src-docs/src/views/tables/custom/custom.js
+++ b/src-docs/src/views/tables/custom/custom.js
@@ -27,7 +27,6 @@ import {
   EuiTableRowCell,
   EuiTableRowCellCheckbox,
   EuiTableSortMobile,
-  EuiTableSortMobileItem,
   EuiTableHeaderMobile,
 } from '../../../../../src/components';
 
@@ -356,34 +355,38 @@ export default class extends Component {
     );
   }
 
-  renderHeaderCells(mobile) {
-    return this.columns.map((column, columnIndex) => {
-      if (column.isCheckbox) {
-        if (!mobile) {
-          return (
-            <EuiTableHeaderCellCheckbox
-              key={column.id}
-              width={column.width}
-            >
-              {this.renderSelectAll()}
-            </EuiTableHeaderCellCheckbox>
-          );
-        }
+  getTableMobileSortItems() {
+    const items = [];
+    this.columns.forEach((column) => {
+      if (column.isCheckbox || !column.isSortable) {
+        return;
       }
+      items.push({
+        name: column.label,
+        key: column.id,
+        onSort: this.onSort.bind(this, column.id),
+        isSorted: this.state.sortedColumn === column.id,
+        isSortAscending: this.sortableProperties.isAscendingByName(column.id),
+      });
+    });
+    return items.length ? items : null;
+  }
 
-      if (mobile) {
-        return (
-          <EuiTableSortMobileItem
+  renderHeaderCells() {
+    const headers = [];
+
+    this.columns.forEach((column, columnIndex) => {
+      if (column.isCheckbox) {
+        headers.push(
+          <EuiTableHeaderCellCheckbox
             key={column.id}
-            onSort={column.isSortable ? this.onSort.bind(this, column.id) : undefined}
-            isSorted={this.state.sortedColumn === column.id}
-            isSortAscending={this.sortableProperties.isAscendingByName(column.id)}
+            width={column.width}
           >
-            {column.label}
-          </EuiTableSortMobileItem>
+            {this.renderSelectAll()}
+          </EuiTableHeaderCellCheckbox>
         );
       } else {
-        return (
+        headers.push(
           <EuiTableHeaderCell
             key={column.id}
             align={this.columns[columnIndex].alignment}
@@ -398,6 +401,8 @@ export default class extends Component {
         );
       }
     });
+
+    return headers.length ? headers : null;
   }
 
   renderRows() {
@@ -557,9 +562,7 @@ export default class extends Component {
           <EuiFlexGroup responsive={false} justifyContent="spaceBetween" alignItems="baseline">
             <EuiFlexItem grow={false}>{this.renderSelectAll(true)}</EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiTableSortMobile anchorPosition="downRight">
-                {this.renderHeaderCells(true)}
-              </EuiTableSortMobile>
+              <EuiTableSortMobile items={this.getTableMobileSortItems()} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiTableHeaderMobile>

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -21,6 +21,7 @@ exports[`EuiBasicTable basic - empty - custom message 1`] = `
           <EuiTableRowCell
             align="center"
             colSpan={1}
+            isMobileFullWidth={true}
             textOnly={true}
           >
             where my items at?
@@ -53,6 +54,7 @@ exports[`EuiBasicTable basic - empty - custom message as node 1`] = `
           <EuiTableRowCell
             align="center"
             colSpan={1}
+            isMobileFullWidth={true}
             textOnly={true}
           >
             <p>
@@ -93,6 +95,7 @@ exports[`EuiBasicTable basic - empty 1`] = `
           <EuiTableRowCell
             align="center"
             colSpan={1}
+            isMobileFullWidth={true}
             textOnly={true}
           >
             No items found
@@ -428,6 +431,7 @@ exports[`EuiBasicTable with pagination and error 1`] = `
           <EuiTableRowCell
             align="center"
             colSpan={1}
+            isMobileFullWidth={true}
             textOnly={true}
           >
             <EuiIcon
@@ -583,16 +587,20 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
 >
   <div>
     <EuiTableHeaderMobile>
-      <EuiTableSortMobile>
-        <EuiTableSortMobileItem
-          isSortAscending={true}
-          isSorted={true}
-          key="_data_s_name_0"
-          onSort={[Function]}
-        >
-          Name
-        </EuiTableSortMobileItem>
-      </EuiTableSortMobile>
+      <EuiTableSortMobile
+        items={
+          Array [
+            Object {
+              "hideForMobile": undefined,
+              "isSortAscending": true,
+              "isSorted": true,
+              "key": "_data_s_name_0",
+              "name": "Name",
+              "onSort": [Function],
+            },
+          ]
+        }
+      />
     </EuiTableHeaderMobile>
     <EuiTable>
       <EuiTableHeader>
@@ -729,16 +737,20 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
 >
   <div>
     <EuiTableHeaderMobile>
-      <EuiTableSortMobile>
-        <EuiTableSortMobileItem
-          isSortAscending={true}
-          isSorted={true}
-          key="_data_s_name_0"
-          onSort={[Function]}
-        >
-          Name
-        </EuiTableSortMobileItem>
-      </EuiTableSortMobile>
+      <EuiTableSortMobile
+        items={
+          Array [
+            Object {
+              "hideForMobile": undefined,
+              "isSortAscending": true,
+              "isSorted": true,
+              "key": "_data_s_name_0",
+              "name": "Name",
+              "onSort": [Function],
+            },
+          ]
+        }
+      />
     </EuiTableHeaderMobile>
     <EuiTable>
       <EuiTableHeader>
@@ -966,16 +978,20 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
 >
   <div>
     <EuiTableHeaderMobile>
-      <EuiTableSortMobile>
-        <EuiTableSortMobileItem
-          isSortAscending={true}
-          isSorted={true}
-          key="_data_s_count_0"
-          onSort={[Function]}
-        >
-          Count
-        </EuiTableSortMobileItem>
-      </EuiTableSortMobile>
+      <EuiTableSortMobile
+        items={
+          Array [
+            Object {
+              "hideForMobile": undefined,
+              "isSortAscending": true,
+              "isSorted": true,
+              "key": "_data_s_count_0",
+              "name": "Count",
+              "onSort": [Function],
+            },
+          ]
+        }
+      />
     </EuiTableHeaderMobile>
     <EuiTable>
       <EuiTableHeader>
@@ -1112,16 +1128,20 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
 >
   <div>
     <EuiTableHeaderMobile>
-      <EuiTableSortMobile>
-        <EuiTableSortMobileItem
-          isSortAscending={true}
-          isSorted={true}
-          key="_data_s_name_0"
-          onSort={[Function]}
-        >
-          Name
-        </EuiTableSortMobileItem>
-      </EuiTableSortMobile>
+      <EuiTableSortMobile
+        items={
+          Array [
+            Object {
+              "hideForMobile": undefined,
+              "isSortAscending": true,
+              "isSorted": true,
+              "key": "_data_s_name_0",
+              "name": "Name",
+              "onSort": [Function],
+            },
+          ]
+        }
+      />
     </EuiTableHeaderMobile>
     <EuiTable>
       <EuiTableHeader>
@@ -1258,16 +1278,20 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
 >
   <div>
     <EuiTableHeaderMobile>
-      <EuiTableSortMobile>
-        <EuiTableSortMobileItem
-          isSortAscending={true}
-          isSorted={true}
-          key="_data_s_name_0"
-          onSort={[Function]}
-        >
-          Name
-        </EuiTableSortMobileItem>
-      </EuiTableSortMobile>
+      <EuiTableSortMobile
+        items={
+          Array [
+            Object {
+              "hideForMobile": undefined,
+              "isSortAscending": true,
+              "isSorted": true,
+              "key": "_data_s_name_0",
+              "name": "Name",
+              "onSort": [Function],
+            },
+          ]
+        }
+      />
     </EuiTableHeaderMobile>
     <EuiTable>
       <EuiTableHeader>
@@ -1489,16 +1513,20 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
 >
   <div>
     <EuiTableHeaderMobile>
-      <EuiTableSortMobile>
-        <EuiTableSortMobileItem
-          isSortAscending={true}
-          isSorted={true}
-          key="_data_s_count_0"
-          onSort={[Function]}
-        >
-          Count
-        </EuiTableSortMobileItem>
-      </EuiTableSortMobile>
+      <EuiTableSortMobile
+        items={
+          Array [
+            Object {
+              "hideForMobile": undefined,
+              "isSortAscending": true,
+              "isSorted": true,
+              "key": "_data_s_count_0",
+              "name": "Count",
+              "onSort": [Function],
+            },
+          ]
+        }
+      />
     </EuiTableHeaderMobile>
     <EuiTable>
       <EuiTableHeader>
@@ -1706,16 +1734,20 @@ exports[`EuiBasicTable with sorting 1`] = `
 >
   <div>
     <EuiTableHeaderMobile>
-      <EuiTableSortMobile>
-        <EuiTableSortMobileItem
-          isSortAscending={true}
-          isSorted={true}
-          key="_data_s_name_0"
-          onSort={[Function]}
-        >
-          Name
-        </EuiTableSortMobileItem>
-      </EuiTableSortMobile>
+      <EuiTableSortMobile
+        items={
+          Array [
+            Object {
+              "hideForMobile": undefined,
+              "isSortAscending": true,
+              "isSorted": true,
+              "key": "_data_s_name_0",
+              "name": "Name",
+              "onSort": [Function],
+            },
+          ]
+        }
+      />
     </EuiTableHeaderMobile>
     <EuiTable>
       <EuiTableHeader>

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -591,7 +591,6 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
         items={
           Array [
             Object {
-              "hideForMobile": undefined,
               "isSortAscending": true,
               "isSorted": true,
               "key": "_data_s_name_0",
@@ -741,7 +740,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
         items={
           Array [
             Object {
-              "hideForMobile": undefined,
               "isSortAscending": true,
               "isSorted": true,
               "key": "_data_s_name_0",
@@ -982,7 +980,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
         items={
           Array [
             Object {
-              "hideForMobile": undefined,
               "isSortAscending": true,
               "isSorted": true,
               "key": "_data_s_count_0",
@@ -1132,7 +1129,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
         items={
           Array [
             Object {
-              "hideForMobile": undefined,
               "isSortAscending": true,
               "isSorted": true,
               "key": "_data_s_name_0",
@@ -1282,7 +1278,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
         items={
           Array [
             Object {
-              "hideForMobile": undefined,
               "isSortAscending": true,
               "isSorted": true,
               "key": "_data_s_name_0",
@@ -1517,7 +1512,6 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
         items={
           Array [
             Object {
-              "hideForMobile": undefined,
               "isSortAscending": true,
               "isSorted": true,
               "key": "_data_s_count_0",
@@ -1738,7 +1732,6 @@ exports[`EuiBasicTable with sorting 1`] = `
         items={
           Array [
             Object {
-              "hideForMobile": undefined,
               "isSortAscending": true,
               "isSorted": true,
               "key": "_data_s_name_0",

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -28,7 +28,6 @@ import { EuiIcon } from '../icon/icon';
 import { LoadingTableBody } from './loading_table_body';
 import { EuiTableHeaderMobile } from '../table/mobile/table_header_mobile';
 import { EuiTableSortMobile } from '../table/mobile/table_sort_mobile';
-import { EuiTableSortMobileItem } from '../table/mobile/table_sort_mobile_item';
 
 const dataTypesProfiles = {
   auto: {
@@ -312,32 +311,31 @@ export class EuiBasicTable extends Component {
   }
 
   renderTableMobileSort() {
+    const { columns, sorting } = this.props;
+    const items = [];
 
-    const { columns } = this.props;
-
-    const sorts = [];
+    if (!sorting) {
+      return null;
+    }
 
     columns.forEach((column, index) => {
-      const sorting = {};
-      if (this.props.sorting && column.sortable) {
-        const sortDirection = this.resolveColumnSortDirection(column);
-        sorting.isSorted = !!sortDirection;
-        sorting.isSortAscending = sortDirection ? SortDirection.isAsc(sortDirection) : undefined;
-        sorting.onSort = this.resolveColumnOnSort(column);
-
-        sorts.push(
-          <EuiTableSortMobileItem
-            key={`_data_s_${column.field}_${index}`}
-            {...sorting}
-            hideForMobile={column.hideForMobile}
-          >
-            {column.name}
-          </EuiTableSortMobileItem>
-        );
+      if(!column.sortable) {
+        return;
       }
+
+      const sortDirection = this.resolveColumnSortDirection(column);
+
+      items.push({
+        name: column.name,
+        key: `_data_s_${column.field}_${index}`,
+        onSort: this.resolveColumnOnSort(column),
+        isSorted: !!sortDirection,
+        isSortAscending: sortDirection ? SortDirection.isAsc(sortDirection) : undefined,
+        hideForMobile: column.hideForMobile,
+      });
     });
 
-    return sorts.length ? <EuiTableSortMobile>{sorts}</EuiTableSortMobile> : null;
+    return items.length ? <EuiTableSortMobile items={items} /> : null;
   }
 
   renderTableHead() {
@@ -457,7 +455,7 @@ export class EuiBasicTable extends Component {
     return (
       <EuiTableBody>
         <EuiTableRow>
-          <EuiTableRowCell align="center" colSpan={colSpan}>
+          <EuiTableRowCell align="center" colSpan={colSpan} isMobileFullWidth={true}>
             <EuiIcon type="minusInCircle" color="danger"/> {error}
           </EuiTableRowCell>
         </EuiTableRow>
@@ -471,7 +469,7 @@ export class EuiBasicTable extends Component {
     return (
       <EuiTableBody>
         <EuiTableRow>
-          <EuiTableRowCell align="center" colSpan={colSpan}>
+          <EuiTableRowCell align="center" colSpan={colSpan} isMobileFullWidth={true}>
             {noItemsMessage}
           </EuiTableRowCell>
         </EuiTableRow>
@@ -521,8 +519,6 @@ export class EuiBasicTable extends Component {
         </EuiTableRowCell>
       </EuiTableRow>
     ) : undefined;
-
-    console.log(itemIdToExpandedRowMap);
 
     return (
       <Fragment key={`row_${itemId}`}>
@@ -691,7 +687,7 @@ export class EuiBasicTable extends Component {
     return profile.align;
   }
 
-  resolveColumnSortDirection(column) {
+  resolveColumnSortDirection = (column) => {
     const { sorting } = this.props;
     if (!sorting || !sorting.sort || !column.sortable) {
       return;
@@ -701,7 +697,7 @@ export class EuiBasicTable extends Component {
     }
   }
 
-  resolveColumnOnSort(column) {
+  resolveColumnOnSort = (column) => {
     const { sorting } = this.props;
     if (!sorting || !column.sortable) {
       return;

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -319,7 +319,7 @@ export class EuiBasicTable extends Component {
     }
 
     columns.forEach((column, index) => {
-      if(!column.sortable) {
+      if(!column.sortable || column.hideForMobile) {
         return;
       }
 
@@ -331,7 +331,6 @@ export class EuiBasicTable extends Component {
         onSort: this.resolveColumnOnSort(column),
         isSorted: !!sortDirection,
         isSortAscending: sortDirection ? SortDirection.isAsc(sortDirection) : undefined,
-        hideForMobile: column.hideForMobile,
       });
     });
 

--- a/src/components/context_menu/context_menu_panel.js
+++ b/src/components/context_menu/context_menu_panel.js
@@ -34,6 +34,7 @@ export class EuiContextMenuPanel extends Component {
     onUseKeyboardToNavigate: PropTypes.func,
     hasFocus: PropTypes.bool,
     items: PropTypes.array,
+    watchedItemProps: PropTypes.array,
     showNextPanel: PropTypes.func,
     showPreviousPanel: PropTypes.func,
     initialFocusedItemIndex: PropTypes.number
@@ -219,6 +220,22 @@ export class EuiContextMenuPanel extends Component {
     }
   }
 
+  getWatchedProps(items) {
+    const { watchedItemProps } = this.props;
+
+    if(items && items.length && watchedItemProps && watchedItemProps.length) {
+      return items.map(item => {
+        const props = {
+          key: item.key,
+        };
+        watchedItemProps.forEach(prop => props[prop] = item.props[prop]);
+        return props;
+      });
+    }
+
+    return null;
+  }
+
   shouldComponentUpdate(nextProps, nextState) {
     // Prevent calling `this.updateFocus()` below if we don't have to.
     if (nextProps.hasFocus !== this.props.hasFocus) {
@@ -230,6 +247,10 @@ export class EuiContextMenuPanel extends Component {
     }
 
     if (nextState.focusedItemIndex !== this.state.focusedItemIndex) {
+      return true;
+    }
+
+    if(JSON.stringify(this.getWatchedProps(nextProps.items)) !== JSON.stringify(this.getWatchedProps(this.props.items))) {
       return true;
     }
 
@@ -276,6 +297,7 @@ export class EuiContextMenuPanel extends Component {
       onUseKeyboardToNavigate, // eslint-disable-line no-unused-vars
       hasFocus, // eslint-disable-line no-unused-vars
       items,
+      watchedItemProps, // eslint-disable-line no-unused-vars
       initialFocusedItemIndex, // eslint-disable-line no-unused-vars
       showNextPanel, // eslint-disable-line no-unused-vars
       showPreviousPanel, // eslint-disable-line no-unused-vars

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile_item.test.js.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile_item.test.js.snap
@@ -11,7 +11,7 @@ exports[`EuiTableSortMobileItem is rendered 1`] = `
     class="euiContextMenu__itemLayout"
   >
     <svg
-      class="euiIcon euiContextMenu__icon euiIcon--medium"
+      class="euiIcon euiIcon--medium euiContextMenu__icon"
       height="16"
       viewBox="0 0 16 16"
       width="16"

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile_item.test.js.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile_item.test.js.snap
@@ -1,3 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiTableSortMobileItem is rendered 1`] = `null`;
+exports[`EuiTableSortMobileItem is rendered 1`] = `
+<button
+  aria-label="aria-label"
+  class="euiContextMenuItem euiTableSortMobileItem testClass1 testClass2"
+  data-test-subj="test subject string"
+  type="button"
+>
+  <span
+    class="euiContextMenu__itemLayout"
+  >
+    <svg
+      class="euiIcon euiContextMenu__icon euiIcon--medium"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+    <span
+      class="euiContextMenuItem__text"
+    />
+  </span>
+</button>
+`;

--- a/src/components/table/mobile/_index.scss
+++ b/src/components/table/mobile/_index.scss
@@ -175,6 +175,11 @@
 
     &.euiTableRowCell--isMobileFullWidth {
       width: 100%;
+
+      .euiTableCellContent--alignCenter {
+        justify-content: center;
+        text-align: center;
+      }
     }
   }
 

--- a/src/components/table/mobile/_index.scss
+++ b/src/components/table/mobile/_index.scss
@@ -18,10 +18,6 @@
 
   .euiTableSortMobile {
     display: block;
-
-    .euiTableSortMobileItem--hideForMobile {
-      display: none;
-    }
   }
 
   // Not allowing compressed styles in mobile view (for now)

--- a/src/components/table/mobile/table_sort_mobile.js
+++ b/src/components/table/mobile/table_sort_mobile.js
@@ -1,17 +1,16 @@
-import React, {
-  Component,
-} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { EuiButtonEmpty } from '../../button/button_empty';
 import { EuiPopover } from '../../popover';
 import { EuiContextMenuPanel } from '../../context_menu';
+import { EuiTableSortMobileItem } from './table_sort_mobile_item';
 
 export class EuiTableSortMobile extends Component {
   static propTypes = {
-    children: PropTypes.node,
     className: PropTypes.string,
+    items: PropTypes.array,
   }
 
   constructor(props) {
@@ -36,9 +35,8 @@ export class EuiTableSortMobile extends Component {
 
   render() {
     const {
-      children,
       className,
-      anchorPosition,
+      items,
       ...rest
     } = this.props;
 
@@ -65,14 +63,29 @@ export class EuiTableSortMobile extends Component {
         ownFocus
         button={mobileSortButton}
         isOpen={this.state.isPopoverOpen}
-        closePopover={this.closePopover.bind(this)}
-        anchorPosition={anchorPosition || "downRight"}
+        closePopover={this.closePopover}
+        anchorPosition="downRight"
         panelPaddingSize="none"
         {...rest}
       >
         <EuiContextMenuPanel
           style={{ minWidth: 200 }}
-          items={children}
+          items={items && items.length ? items.map(item => {
+            return (
+              <EuiTableSortMobileItem
+                key={item.key}
+                onSort={() => {
+                  item.onSort();
+                  this.closePopover();
+                }}
+                isSorted={item.isSorted}
+                isSortAscending={item.isSortAscending}
+                hideForMobile={item.hideForMobile}
+              >
+                {item.name}
+              </EuiTableSortMobileItem>
+            );
+          }) : null}
         />
       </EuiPopover>
     );

--- a/src/components/table/mobile/table_sort_mobile.js
+++ b/src/components/table/mobile/table_sort_mobile.js
@@ -10,6 +10,7 @@ import { EuiTableSortMobileItem } from './table_sort_mobile_item';
 export class EuiTableSortMobile extends Component {
   static propTypes = {
     className: PropTypes.string,
+    anchorPosition: PropTypes.string,
     items: PropTypes.array,
   }
 
@@ -19,6 +20,10 @@ export class EuiTableSortMobile extends Component {
     this.state = {
       isPopoverOpen: false,
     };
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return JSON.stringify(nextProps) !== JSON.stringify(this.props) || JSON.stringify(nextState) !== JSON.stringify(this.state);
   }
 
   onButtonClick = () => {
@@ -36,6 +41,7 @@ export class EuiTableSortMobile extends Component {
   render() {
     const {
       className,
+      anchorPosition,
       items,
       ...rest
     } = this.props;
@@ -64,7 +70,7 @@ export class EuiTableSortMobile extends Component {
         button={mobileSortButton}
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover}
-        anchorPosition="downRight"
+        anchorPosition={anchorPosition || "downRight"}
         panelPaddingSize="none"
         {...rest}
       >
@@ -74,18 +80,15 @@ export class EuiTableSortMobile extends Component {
             return (
               <EuiTableSortMobileItem
                 key={item.key}
-                onSort={() => {
-                  item.onSort();
-                  this.closePopover();
-                }}
+                onSort={item.onSort}
                 isSorted={item.isSorted}
                 isSortAscending={item.isSortAscending}
-                hideForMobile={item.hideForMobile}
               >
                 {item.name}
               </EuiTableSortMobileItem>
             );
           }) : null}
+          watchedItemProps={['isSorted', 'isSortAscending']}
         />
       </EuiPopover>
     );

--- a/src/components/table/mobile/table_sort_mobile_item.js
+++ b/src/components/table/mobile/table_sort_mobile_item.js
@@ -15,34 +15,31 @@ export const EuiTableSortMobileItem = ({
   ...rest
 }) => {
 
-  if (onSort) {
-    let sortIcon = 'empty';
-    if (isSorted) {
-      sortIcon = isSortAscending ? 'sortUp' : 'sortDown';
-    }
+  let sortIcon = 'empty';
+  if (isSorted) {
+    sortIcon = isSortAscending ? 'sortUp' : 'sortDown';
+  }
 
-    const buttonClasses = classNames('euiTableSortMobileItem', className, {
-      'euiTableSortMobileItem-isSorted': isSorted,
-      'euiTableSortMobileItem--hideForMobile': hideForMobile,
-    });
+  const buttonClasses = classNames('euiTableSortMobileItem', className, {
+    'euiTableSortMobileItem-isSorted': isSorted,
+    'euiTableSortMobileItem--hideForMobile': hideForMobile,
+  });
 
     const columnTitle = ariaLabel ? ariaLabel : children;
     const statefulAriaLabel = `Sort ${columnTitle} ${isSortAscending ? 'descending' : 'ascending'}`;
 
-    return (
-      <EuiContextMenuItem
-        className={buttonClasses}
-        icon={sortIcon}
-        onClick={onSort}
-        aria-label={statefulAriaLabel}
-        {...rest}
-      >
-        {children}
-      </EuiContextMenuItem>
-    );
-  }
+  return (
+    <EuiContextMenuItem
+      className={buttonClasses}
+      icon={sortIcon}
+      onClick={onSort}
+      aria-label={statefulAriaLabel}
+      {...rest}
+    >
+      {children}
+    </EuiContextMenuItem>
+  );
 
-  return null;
 };
 
 EuiTableSortMobileItem.propTypes = {

--- a/src/components/table/mobile/table_sort_mobile_item.js
+++ b/src/components/table/mobile/table_sort_mobile_item.js
@@ -11,7 +11,6 @@ export const EuiTableSortMobileItem = ({
   isSortAscending,
   className,
   ariaLabel,
-  hideForMobile,
   ...rest
 }) => {
 
@@ -22,7 +21,6 @@ export const EuiTableSortMobileItem = ({
 
   const buttonClasses = classNames('euiTableSortMobileItem', className, {
     'euiTableSortMobileItem-isSorted': isSorted,
-    'euiTableSortMobileItem--hideForMobile': hideForMobile,
   });
 
     const columnTitle = ariaLabel ? ariaLabel : children;
@@ -48,5 +46,4 @@ EuiTableSortMobileItem.propTypes = {
   onSort: PropTypes.func,
   isSorted: PropTypes.bool,
   isSortAscending: PropTypes.bool,
-  hideForMobile: PropTypes.bool,
 };


### PR DESCRIPTION
- Make `EuiTableSortMobile` render `EuiTableSortMobileItems`
- Make loading & loading error message centered like on desktop view
- Fix issue where `EuiTableSortMobile` was re-rendering unnecessarily by adding `shouldComponentUpdate`
- Remove `hideForMobile` flag - just don't render the item if true
- `ContextMenuPanel` now updates with new sorting without having to close the popover - done by adding prop `watchedItemProps` to the component, which is used in its `shouldComponentUpdate` logic