### PR TITLE
Add keyboard functionality to super select

### DIFF
--- a/src-docs/src/views/super_select/super_select.js
+++ b/src-docs/src/views/super_select/super_select.js
@@ -19,7 +19,7 @@ export default class extends Component {
       },
       {
         value: 'option_two',
-        inputDisplay: "Option two",
+        inputDisplay: 'Option two',
       },
       {
         value: 'option_three',

--- a/src-docs/src/views/super_select/super_select_complex.js
+++ b/src-docs/src/views/super_select/super_select_complex.js
@@ -29,7 +29,7 @@ export default class extends Component {
       },
       {
         value: 'option_two',
-        inputDisplay: "Option two",
+        inputDisplay: 'Option two',
         dropdownDisplay: (
           <Fragment>
             <strong>Option two</strong>

--- a/src/components/context_menu/context_menu_item.js
+++ b/src/components/context_menu/context_menu_item.js
@@ -176,6 +176,6 @@ export class EuiContextMenuItem extends Component {
 }
 
 EuiContextMenuItem.defaultProps = {
-  toolTipPosition: "right",
-  layoutAlign: "center",
+  toolTipPosition: 'right',
+  layoutAlign: 'center',
 };

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -31,7 +31,7 @@ export class EuiSuperSelect extends Component {
       isPopoverOpen: true,
     });
 
-    function focusSelected() {
+    const focusSelected = () => {
       const indexOfSelected = this.props.options.reduce(
         (indexOfSelected, option, index) => {
           if (indexOfSelected != null) return indexOfSelected;
@@ -46,7 +46,7 @@ export class EuiSuperSelect extends Component {
       } else {
         requestAnimationFrame(focusSelected);
       }
-    }
+    };
 
     requestAnimationFrame(focusSelected);
   };

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -41,8 +41,10 @@ export class EuiSuperSelect extends Component {
         null
       );
 
+      // valueOfSelected is optional, and options may not exist yet
       if (indexOfSelected != null) {
-        this.focusItemAt(indexOfSelected);
+        // wait for the CSS classes to be applied, removing visibility: hidden
+        requestAnimationFrame(() => this.focusItemAt(indexOfSelected));
       } else {
         requestAnimationFrame(focusSelected);
       }

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -3,6 +3,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import tabbable from 'tabbable';
 
 import { EuiSuperSelectControl } from './super_select_control';
 import { EuiPopover } from '../../popover';
@@ -17,10 +18,18 @@ export class EuiSuperSelect extends Component {
     };
   }
 
-  onButtonClick = () => {
-    this.setState(prevState => ({
-      isPopoverOpen: !prevState.isPopoverOpen,
-    }));
+  setItemNode = (node, index) => {
+
+  };
+
+  openPopover = () => {
+    this.setState({
+      isPopoverOpen: true,
+    });
+
+    requestAnimationFrame(() => {
+      tabbable();
+    });
   };
 
   closePopover = () => {
@@ -69,7 +78,7 @@ export class EuiSuperSelect extends Component {
         options={options}
         value={valueOfSelected}
         onChange={onChange}
-        onClick={this.onButtonClick}
+        onClick={this.state.isPopoverOpen ? this.closePopover : this.openPopover}
         className={buttonClasses}
         {...rest}
       />
@@ -80,9 +89,10 @@ export class EuiSuperSelect extends Component {
         <EuiContextMenuItem
           key={index}
           className={itemClasses}
-          icon={valueOfSelected === option.value ? "check" : "empty"}
+          icon={valueOfSelected === option.value ? 'check' : 'empty'}
           onClick={() => this.itemClicked(option.value)}
           layoutAlign={itemLayoutAlign}
+          buttonRef={node => this.setItemNode(node, index)}
         >
           {option.dropdownDisplay || option.inputDisplay}
         </EuiContextMenuItem>
@@ -98,6 +108,7 @@ export class EuiSuperSelect extends Component {
         closePopover={this.closePopover}
         panelPaddingSize="none"
         anchorPosition="downCenter"
+        ownFocus={true}
       >
         {items}
       </EuiPopover>


### PR DESCRIPTION
- Keyboard up/down arrows will open the options list when super select box is focused
- Tab key is disabled when an option is focused
- Up/down arrows navigate/cycle through options
- Selected option is focused when menu opens