### PR TITLE
Super select screen readers

### DIFF
--- a/src-docs/src/views/super_select/super_select.js
+++ b/src-docs/src/views/super_select/super_select.js
@@ -45,7 +45,6 @@ export default class extends Component {
           options={this.options}
           valueOfSelected={this.state.value}
           onChange={this.onChange}
-          aria-label="Use aria labels when no actual label is in use"
         />
 
         <EuiSpacer size="m" />
@@ -55,7 +54,6 @@ export default class extends Component {
           valueOfSelected={this.state.value}
           onChange={this.onChange}
           disabled
-          aria-label="Use aria labels when no actual label is in use"
         />
 
         <EuiSpacer size="m" />
@@ -65,7 +63,6 @@ export default class extends Component {
           valueOfSelected={this.state.value}
           onChange={this.onChange}
           isLoading
-          aria-label="Use aria labels when no actual label is in use"
         />
 
         <EuiSpacer size="m" />
@@ -76,7 +73,6 @@ export default class extends Component {
           onChange={this.onChange}
           isLoading
           disabled
-          aria-label="Use aria labels when no actual label is in use"
         />
 
         <EuiSpacer size="m" />

--- a/src-docs/src/views/super_select/super_select_basic.js
+++ b/src-docs/src/views/super_select/super_select_basic.js
@@ -55,7 +55,6 @@ export default class extends Component {
         options={this.options}
         valueOfSelected={this.state.value}
         onChange={this.onChange}
-        aria-label="Health levels"
       />
     );
   }

--- a/src-docs/src/views/super_select/super_select_complex.js
+++ b/src-docs/src/views/super_select/super_select_complex.js
@@ -57,12 +57,14 @@ export default class extends Component {
 
     this.state = {
       value: this.options[1].value,
+      inputDisplay: this.options[1].inputDisplay,
     };
   }
 
   onChange = (value) => {
     this.setState({
       value: value,
+      inputDisplay: this.options.inputDisplay,
     });
   };
 
@@ -74,7 +76,6 @@ export default class extends Component {
         onChange={this.onChange}
         itemLayoutAlign="top"
         hasDividers
-        aria-label="Use aria labels when no actual label is in use"
       />
     );
   }

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -9,9 +9,7 @@ exports[`EuiSuperSelect is rendered 1`] = `
   >
     <select
       aria-hidden="true"
-      aria-label="aria-label"
       class="euiSuperSelectControl__hiddenField"
-      data-test-subj="test subject string"
     />
     <div
       class="euiFormControlLayout"
@@ -20,6 +18,7 @@ exports[`EuiSuperSelect is rendered 1`] = `
         class="euiFormControlLayout__childrenWrapper"
       >
         <button
+          aria-haspopup="true"
           aria-label="aria-label"
           class="euiSuperSelectControl testClass1 testClass2"
           data-test-subj="test subject string"
@@ -86,6 +85,8 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
         class="euiFormControlLayout__childrenWrapper"
       >
         <button
+          aria-haspopup="true"
+          aria-label="Select an option: undefined selected."
           class="euiSuperSelectControl"
           role="option"
           type="button"
@@ -150,6 +151,8 @@ exports[`EuiSuperSelect props options are rendered 1`] = `
         class="euiFormControlLayout__childrenWrapper"
       >
         <button
+          aria-haspopup="true"
+          aria-label="Select an option: undefined selected."
           class="euiSuperSelectControl"
           role="option"
           type="button"

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -19,9 +19,16 @@ exports[`EuiSuperSelect is rendered 1`] = `
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
+        <span
+          class="euiScreenReaderOnly"
+          id="generated-id"
+        >
+          Select an option: , is selected
+        </span>
         <button
           aria-haspopup="true"
           aria-label="aria-label"
+          aria-labelledby="generated-id"
           class="euiSuperSelectControl testClass1 testClass2"
           data-test-subj="test subject string"
           role="option"
@@ -86,9 +93,15 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
+        <span
+          class="euiScreenReaderOnly"
+          id="generated-id"
+        >
+          Select an option: , is selected
+        </span>
         <button
           aria-haspopup="true"
-          aria-label="Select an option:  selected"
+          aria-labelledby="generated-id"
           class="euiSuperSelectControl"
           role="option"
           type="button"
@@ -152,9 +165,15 @@ exports[`EuiSuperSelect props options are rendered 1`] = `
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
+        <span
+          class="euiScreenReaderOnly"
+          id="generated-id"
+        >
+          Select an option: , is selected
+        </span>
         <button
           aria-haspopup="true"
-          aria-label="Select an option:  selected"
+          aria-labelledby="generated-id"
           class="euiSuperSelectControl"
           role="option"
           type="button"
@@ -219,9 +238,15 @@ exports[`EuiSuperSelect props valueSelected is rendered 1`] = `
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
+        <span
+          class="euiScreenReaderOnly"
+          id="generated-id"
+        >
+          Select an option: Option #1, is selected
+        </span>
         <button
           aria-haspopup="true"
-          aria-label="Select an option: Option #1 selected"
+          aria-labelledby="generated-id"
           class="euiSuperSelectControl"
           role="option"
           type="button"

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -9,7 +9,9 @@ exports[`EuiSuperSelect is rendered 1`] = `
   >
     <select
       aria-hidden="true"
+      aria-label="aria-label"
       class="euiSuperSelectControl__hiddenField"
+      data-test-subj="test subject string"
     />
     <div
       class="euiFormControlLayout"
@@ -86,7 +88,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
       >
         <button
           aria-haspopup="true"
-          aria-label="Select an option: undefined selected."
+          aria-label="Select an option:  selected"
           class="euiSuperSelectControl"
           role="option"
           type="button"
@@ -152,7 +154,7 @@ exports[`EuiSuperSelect props options are rendered 1`] = `
       >
         <button
           aria-haspopup="true"
-          aria-label="Select an option: undefined selected."
+          aria-label="Select an option:  selected"
           class="euiSuperSelectControl"
           role="option"
           type="button"
@@ -218,6 +220,8 @@ exports[`EuiSuperSelect props valueSelected is rendered 1`] = `
         class="euiFormControlLayout__childrenWrapper"
       >
         <button
+          aria-haspopup="true"
+          aria-label="Select an option: Option #1 selected"
           class="euiSuperSelectControl"
           role="option"
           type="button"

--- a/src/components/form/super_select/__snapshots__/super_select_control.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select_control.test.js.snap
@@ -4,7 +4,9 @@ exports[`EuiSuperSelectControl is rendered 1`] = `
 Array [
   <select
     aria-hidden="true"
+    aria-label="aria-label"
     class="euiSuperSelectControl__hiddenField"
+    data-test-subj="test subject string"
   />,
   <div
     class="euiFormControlLayout"
@@ -68,7 +70,7 @@ Array [
     >
       <button
         aria-haspopup="true"
-        aria-label="Select an option: undefined selected."
+        aria-label="Select an option:  selected"
         class="euiSuperSelectControl euiSuperSelectControl--compressed"
         role="option"
         type="button"
@@ -128,7 +130,7 @@ Array [
     >
       <button
         aria-haspopup="true"
-        aria-label="Select an option: undefined selected."
+        aria-label="Select an option:  selected"
         class="euiSuperSelectControl"
         role="option"
         type="button"
@@ -181,7 +183,7 @@ Array [
     >
       <button
         aria-haspopup="true"
-        aria-label="Select an option: undefined selected."
+        aria-label="Select an option:  selected"
         class="euiSuperSelectControl euiSuperSelectControl--fullWidth"
         role="option"
         type="button"
@@ -234,7 +236,7 @@ Array [
     >
       <button
         aria-haspopup="true"
-        aria-label="Select an option: undefined selected."
+        aria-label="Select an option:  selected"
         class="euiSuperSelectControl euiSuperSelectControl-isLoading"
         role="option"
         type="button"
@@ -297,7 +299,7 @@ Array [
     >
       <button
         aria-haspopup="true"
-        aria-label="Select an option: undefined selected."
+        aria-label="Select an option:  selected"
         class="euiSuperSelectControl"
         role="option"
         type="button"
@@ -357,6 +359,8 @@ Array [
       class="euiFormControlLayout__childrenWrapper"
     >
       <button
+        aria-haspopup="true"
+        aria-label="Select an option: Option #1 selected"
         class="euiSuperSelectControl"
         role="option"
         type="button"

--- a/src/components/form/super_select/__snapshots__/super_select_control.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select_control.test.js.snap
@@ -4,9 +4,7 @@ exports[`EuiSuperSelectControl is rendered 1`] = `
 Array [
   <select
     aria-hidden="true"
-    aria-label="aria-label"
     class="euiSuperSelectControl__hiddenField"
-    data-test-subj="test subject string"
   />,
   <div
     class="euiFormControlLayout"
@@ -15,6 +13,7 @@ Array [
       class="euiFormControlLayout__childrenWrapper"
     >
       <button
+        aria-haspopup="true"
         aria-label="aria-label"
         class="euiSuperSelectControl testClass1 testClass2"
         data-test-subj="test subject string"
@@ -68,6 +67,8 @@ Array [
       class="euiFormControlLayout__childrenWrapper"
     >
       <button
+        aria-haspopup="true"
+        aria-label="Select an option: undefined selected."
         class="euiSuperSelectControl euiSuperSelectControl--compressed"
         role="option"
         type="button"
@@ -126,6 +127,8 @@ Array [
       class="euiFormControlLayout__childrenWrapper"
     >
       <button
+        aria-haspopup="true"
+        aria-label="Select an option: undefined selected."
         class="euiSuperSelectControl"
         role="option"
         type="button"
@@ -177,6 +180,8 @@ Array [
       class="euiFormControlLayout__childrenWrapper"
     >
       <button
+        aria-haspopup="true"
+        aria-label="Select an option: undefined selected."
         class="euiSuperSelectControl euiSuperSelectControl--fullWidth"
         role="option"
         type="button"
@@ -228,6 +233,8 @@ Array [
       class="euiFormControlLayout__childrenWrapper"
     >
       <button
+        aria-haspopup="true"
+        aria-label="Select an option: undefined selected."
         class="euiSuperSelectControl euiSuperSelectControl-isLoading"
         role="option"
         type="button"
@@ -289,6 +296,8 @@ Array [
       class="euiFormControlLayout__childrenWrapper"
     >
       <button
+        aria-haspopup="true"
+        aria-label="Select an option: undefined selected."
         class="euiSuperSelectControl"
         role="option"
         type="button"

--- a/src/components/form/super_select/__snapshots__/super_select_control.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select_control.test.js.snap
@@ -14,9 +14,16 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
+      <span
+        class="euiScreenReaderOnly"
+        id="generated-id"
+      >
+        Select an option: , is selected
+      </span>
       <button
         aria-haspopup="true"
         aria-label="aria-label"
+        aria-labelledby="generated-id"
         class="euiSuperSelectControl testClass1 testClass2"
         data-test-subj="test subject string"
         role="option"
@@ -68,9 +75,15 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
+      <span
+        class="euiScreenReaderOnly"
+        id="generated-id"
+      >
+        Select an option: , is selected
+      </span>
       <button
         aria-haspopup="true"
-        aria-label="Select an option:  selected"
+        aria-labelledby="generated-id"
         class="euiSuperSelectControl euiSuperSelectControl--compressed"
         role="option"
         type="button"
@@ -128,9 +141,15 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
+      <span
+        class="euiScreenReaderOnly"
+        id="generated-id"
+      >
+        Select an option: , is selected
+      </span>
       <button
         aria-haspopup="true"
-        aria-label="Select an option:  selected"
+        aria-labelledby="generated-id"
         class="euiSuperSelectControl"
         role="option"
         type="button"
@@ -181,9 +200,15 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
+      <span
+        class="euiScreenReaderOnly"
+        id="generated-id"
+      >
+        Select an option: , is selected
+      </span>
       <button
         aria-haspopup="true"
-        aria-label="Select an option:  selected"
+        aria-labelledby="generated-id"
         class="euiSuperSelectControl euiSuperSelectControl--fullWidth"
         role="option"
         type="button"
@@ -234,9 +259,15 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
+      <span
+        class="euiScreenReaderOnly"
+        id="generated-id"
+      >
+        Select an option: , is selected
+      </span>
       <button
         aria-haspopup="true"
-        aria-label="Select an option:  selected"
+        aria-labelledby="generated-id"
         class="euiSuperSelectControl euiSuperSelectControl-isLoading"
         role="option"
         type="button"
@@ -297,9 +328,15 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
+      <span
+        class="euiScreenReaderOnly"
+        id="generated-id"
+      >
+        Select an option: , is selected
+      </span>
       <button
         aria-haspopup="true"
-        aria-label="Select an option:  selected"
+        aria-labelledby="generated-id"
         class="euiSuperSelectControl"
         role="option"
         type="button"
@@ -358,9 +395,15 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
+      <span
+        class="euiScreenReaderOnly"
+        id="generated-id"
+      >
+        Select an option: Option #1, is selected
+      </span>
       <button
         aria-haspopup="true"
-        aria-label="Select an option: Option #1 selected"
+        aria-labelledby="generated-id"
         class="euiSuperSelectControl"
         role="option"
         type="button"

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -4,6 +4,7 @@ import React, {
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import { EuiScreenReaderOnly } from '../../accessibility';
 import { EuiSuperSelectControl } from './super_select_control';
 import { EuiPopover } from '../../popover';
 import { EuiContextMenuItem } from '../../context_menu';
@@ -182,6 +183,8 @@ export class EuiSuperSelect extends Component {
           layoutAlign={itemLayoutAlign}
           buttonRef={node => this.setItemNode(node, index)}
           style={{ width: this.state.menuWidth }}
+          role="option"
+          id={option.value}
         >
           {option.dropdownDisplay || option.inputDisplay}
         </EuiContextMenuItem>
@@ -201,7 +204,12 @@ export class EuiSuperSelect extends Component {
         popoverRef={this.setPopoverRef}
         hasArrow={false}
       >
-        {items}
+        <EuiScreenReaderOnly>
+          <p role="alert">You are in a popup. To exit this popup, hit escape.</p>
+        </EuiScreenReaderOnly>
+        <div role="listbox" aria-activedescendant={valueOfSelected}>
+          {items}
+        </div>
       </EuiPopover>
     );
   }

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -205,7 +205,10 @@ export class EuiSuperSelect extends Component {
         hasArrow={false}
       >
         <EuiScreenReaderOnly>
-          <p role="alert">You are in a popup. To exit this popup, hit escape.</p>
+          <p role="alert">
+            You are in a form selector of {options.length} items and must select a single option.
+            Use the up and down keys to navigate or escape to close.
+          </p>
         </EuiScreenReaderOnly>
         <div role="listbox" aria-activedescendant={valueOfSelected}>
           {items}

--- a/src/components/form/super_select/super_select.test.js
+++ b/src/components/form/super_select/super_select.test.js
@@ -4,6 +4,8 @@ import { requiredProps } from '../../../test';
 
 import { EuiSuperSelect } from './super_select';
 
+jest.mock(`../form_row/make_id`, () => () => `generated-id`);
+
 describe('EuiSuperSelect', () => {
   test('is rendered', () => {
     const component = render(

--- a/src/components/form/super_select/super_select_control.js
+++ b/src/components/form/super_select/super_select_control.js
@@ -1,8 +1,9 @@
 import React, { Fragment } from 'react';
-import { renderToString } from 'react-dom/server';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import { EuiScreenReaderOnly } from '../../accessibility';
+import makeId from '../form_row/make_id';
 import {
   EuiFormControlLayout,
 } from '../form_control_layout';
@@ -56,9 +57,7 @@ export const EuiSuperSelectControl = ({
     side: 'right',
   };
 
-  // In the case the inputDisplay is a react element, make it a string, then strip the HTML
-  // This is used to read only the text for a screenreader.
-  const selectedValueAsString = renderToString(selectedValue).replace(/<\/?[^>]+(>|$)/g, '');
+  const screenReaderId = makeId();
 
   return (
     <Fragment>
@@ -89,12 +88,22 @@ export const EuiSuperSelectControl = ({
         compressed={compressed}
       >
 
+        {/*
+          This is read when the user tabs in. The comma is important,
+          otherwise the screen reader often combines the text.
+        */}
+        <EuiScreenReaderOnly>
+          <span id={screenReaderId}>
+            Select an option: {selectedValue}, is selected
+          </span>
+        </EuiScreenReaderOnly>
+
         <button
           role="option"
           type="button"
           className={classes}
           aria-haspopup="true"
-          aria-label={`Select an option: ${selectedValueAsString} selected`}
+          aria-labelledby={screenReaderId}
           {...rest}
         >
           {selectedValue}

--- a/src/components/form/super_select/super_select_control.js
+++ b/src/components/form/super_select/super_select_control.js
@@ -65,7 +65,6 @@ export const EuiSuperSelectControl = ({
         defaultValue={selectDefaultValue}
         value={value}
         aria-hidden="true"
-        {...rest}
       >
         {emptyOptionNode}
         {options.map((option, index) => {
@@ -88,6 +87,8 @@ export const EuiSuperSelectControl = ({
           role="option"
           type="button"
           className={classes}
+          aria-haspopup="true"
+          aria-label={`Select an option: ${value} selected.`}
           {...rest}
         >
           {selectedValue}

--- a/src/components/form/super_select/super_select_control.js
+++ b/src/components/form/super_select/super_select_control.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { renderToString } from 'react-dom/server';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -55,6 +56,10 @@ export const EuiSuperSelectControl = ({
     side: 'right',
   };
 
+  // In the case the inputDisplay is a react element, make it a string, then strip the HTML
+  // This is used to read only the text for a screenreader.
+  const selectedValueAsString = renderToString(selectedValue).replace(/<\/?[^>]+(>|$)/g, '');
+
   return (
     <Fragment>
       <select
@@ -65,6 +70,7 @@ export const EuiSuperSelectControl = ({
         defaultValue={selectDefaultValue}
         value={value}
         aria-hidden="true"
+        {...rest}
       >
         {emptyOptionNode}
         {options.map((option, index) => {
@@ -88,7 +94,7 @@ export const EuiSuperSelectControl = ({
           type="button"
           className={classes}
           aria-haspopup="true"
-          aria-label={`Select an option: ${value} selected.`}
+          aria-label={`Select an option: ${selectedValueAsString} selected`}
           {...rest}
         >
           {selectedValue}

--- a/src/components/form/super_select/super_select_control.test.js
+++ b/src/components/form/super_select/super_select_control.test.js
@@ -4,6 +4,8 @@ import { requiredProps } from '../../../test';
 
 import { EuiSuperSelectControl } from './super_select_control';
 
+jest.mock(`../form_row/make_id`, () => () => `generated-id`);
+
 describe('EuiSuperSelectControl', () => {
   test('is rendered', () => {
     const component = render(


### PR DESCRIPTION
Works with the labelledby solution. Text changed to be similar to the others, though for some reason it requires a whole bunch of commas to read correctly. Tested this with form rows as well.