### PR TITLE
Linting fix-ups

### DIFF
--- a/src-docs/src/views/package/i18n_tokens.js
+++ b/src-docs/src/views/package/i18n_tokens.js
@@ -25,9 +25,7 @@ const columns = [
           <EuiLink
             target="_blank"
             color="subdued"
-            href={`https://github.com/elastic/eui/blob/master/${filepath}#L${
-              loc.start.line
-            }`}>
+            href={`https://github.com/elastic/eui/blob/master/${filepath}#L${loc.start.line}`}>
             {filepath}:{loc.start.line}:{loc.start.column}
           </EuiLink>
         </div>

--- a/src-docs/src/views/resize_observer/resize_observer.js
+++ b/src-docs/src/views/resize_observer/resize_observer.js
@@ -55,9 +55,7 @@ export class ResizeObserverExample extends Component {
             </p>
           )}
           <p>
-            <EuiCode>{`height: ${this.state.height}; width: ${
-              this.state.width
-            }`}</EuiCode>
+            <EuiCode>{`height: ${this.state.height}; width: ${this.state.width}`}</EuiCode>
           </p>
         </EuiText>
 

--- a/src-docs/src/views/tables/in_memory/in_memory_search_callback.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_callback.js
@@ -54,9 +54,7 @@ export class Table extends React.Component {
 
       requestTimeoutId = setTimeout(() => {
         const items = store.users.filter(user => {
-          const normalizedName = `${user.firstName} ${
-            user.lastName
-          }`.toLowerCase();
+          const normalizedName = `${user.firstName} ${user.lastName}`.toLowerCase();
           const normalizedQuery = query.text.toLowerCase();
           return normalizedName.indexOf(normalizedQuery) !== -1;
         });

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -993,9 +993,7 @@ export class EuiBasicTable extends Component {
       return;
     }
     if (!this.props.onChange) {
-      throw new Error(`BasicTable is configured to be sortable on column [${
-        column.field
-      }] but
+      throw new Error(`BasicTable is configured to be sortable on column [${column.field}] but
           [onChange] is not configured. This callback must be implemented to handle the sort requests`);
     }
     return () => this.onColumnSortChange(column);

--- a/src/components/basic_table/default_item_action.js
+++ b/src/components/basic_table/default_item_action.js
@@ -16,9 +16,7 @@ export class DefaultItemAction extends Component {
     const { action, enabled, item, className } = this.props;
 
     if (!action.onClick && !action.href) {
-      throw new Error(`Cannot render item action [${
-        action.name
-      }]. Missing required 'onClick' callback
+      throw new Error(`Cannot render item action [${action.name}]. Missing required 'onClick' callback
         or 'href' string. If you want to provide a custom action control, make sure to define the 'render' callback`);
     }
 
@@ -29,9 +27,7 @@ export class DefaultItemAction extends Component {
     let button;
     if (action.type === 'icon') {
       if (!icon) {
-        throw new Error(`Cannot render item action [${
-          action.name
-        }]. It is configured to render as an icon but no
+        throw new Error(`Cannot render item action [${action.name}]. It is configured to render as an icon but no
         icon is provided. Make sure to set the 'icon' property of the action`);
       }
       button = (

--- a/src/components/combo_box/combo_box_input/combo_box_input.js
+++ b/src/components/combo_box/combo_box_input/combo_box_input.js
@@ -145,9 +145,7 @@ export class EuiComboBoxInput extends Component {
           searchValue ? `${searchValue}. Selected. ` : ''
         }${
           selectedOptions.length
-            ? `${value}. Press Backspace to delete ${
-                selectedOptions[selectedOptions.length - 1].label
-              }. `
+            ? `${value}. Press Backspace to delete ${selectedOptions[selectedOptions.length - 1].label}. `
             : ''
         }Combo box input. ${readPlaceholder} Type some text or, to display a list of choices, press Down Arrow. ` +
         'To exit the list of choices, press Escape.';

--- a/src/components/combo_box/index.d.ts
+++ b/src/components/combo_box/index.d.ts
@@ -4,13 +4,15 @@ import {
   FunctionComponent,
   FocusEventHandler,
 } from 'react';
-import { ListProps } from 'react-virtualized'; // eslint-disable-line import/named
+/* eslint-disable import/named */
+import { ListProps } from 'react-virtualized';
 import {
   EuiComboBoxOption,
   EuiComboBoxOptionProps,
   EuiComboBoxOptionsListPosition,
   EuiComboBoxOptionsListProps,
-} from '@elastic/eui'; // eslint-disable-line import/no-unresolved
+} from '@elastic/eui';
+/* eslint-enable import/named */
 import { RefCallback, CommonProps } from '../common';
 
 declare module '@elastic/eui' {

--- a/src/components/combo_box/matching_options.test.ts
+++ b/src/components/combo_box/matching_options.test.ts
@@ -1,4 +1,4 @@
-import { EuiComboBoxOptionProps } from '@elastic/eui'; // eslint-disable-line import/no-unresolved
+import { EuiComboBoxOptionProps } from '@elastic/eui'; // eslint-disable-line import/named
 import {
   flattenOptionGroups,
   getSelectedOptionForSearchValue,

--- a/src/components/combo_box/matching_options.ts
+++ b/src/components/combo_box/matching_options.ts
@@ -1,4 +1,4 @@
-import { EuiComboBoxOptionProps } from '@elastic/eui'; // eslint-disable-line import/no-unresolved
+import { EuiComboBoxOptionProps } from '@elastic/eui'; // eslint-disable-line import/named
 
 export const flattenOptionGroups = (
   optionsOrGroups: EuiComboBoxOptionProps[]

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -87,7 +87,7 @@ React.FunctionComponent<ExclusiveUnion<Spanlike, Buttonlike>>
  * returns { 'four': never, 'five': never }
  */
 export type DisambiguateSet<T, U> = {
-  [P in Exclude<keyof T, keyof U>]?: never
+  [P in Exclude<keyof T, keyof U>]?: never;
 };
 
 /**

--- a/src/components/form/form_control_layout/form_control_layout.js
+++ b/src/components/form/form_control_layout/form_control_layout.js
@@ -37,9 +37,7 @@ export class EuiFormControlLayout extends Component {
     let clonedChildren;
     if ((prepend || append) && children) {
       clonedChildren = cloneElement(children, {
-        className: `${
-          children.props.className
-        } euiFormControlLayout__child--noStyle`,
+        className: `${children.props.className} euiFormControlLayout__child--noStyle`,
       });
     }
 

--- a/src/components/form/form_label/form_label.tsx
+++ b/src/components/form/form_label/form_label.tsx
@@ -46,7 +46,7 @@ export const EuiFormLabel: FunctionComponent<EuiFormLabelProps> = ({
     return (
       <legend
         className={classes}
-        {...rest as HTMLAttributes<HTMLLegendElement>}>
+        {...(rest as HTMLAttributes<HTMLLegendElement>)}>
         {children}
       </legend>
     );
@@ -54,7 +54,7 @@ export const EuiFormLabel: FunctionComponent<EuiFormLabelProps> = ({
     return (
       <label
         className={classes}
-        {...rest as LabelHTMLAttributes<HTMLLabelElement>}>
+        {...(rest as LabelHTMLAttributes<HTMLLabelElement>)}>
         {children}
       </label>
     );

--- a/src/components/form/range/range_track.js
+++ b/src/components/form/range/range_track.js
@@ -14,16 +14,12 @@ export class EuiRangeTrack extends Component {
   validateValueIsInStep = value => {
     if (value < this.props.min) {
       throw new Error(
-        `The value of ${value} is lower than the min value of ${
-          this.props.min
-        }.`
+        `The value of ${value} is lower than the min value of ${this.props.min}.`
       );
     }
     if (value > this.props.max) {
       throw new Error(
-        `The value of ${value} is higher than the max value of ${
-          this.props.max
-        }.`
+        `The value of ${value} is higher than the max value of ${this.props.max}.`
       );
     }
     // Error out if the value doesn't line up with the sequence of steps
@@ -34,9 +30,7 @@ export class EuiRangeTrack extends Component {
       )
     ) {
       throw new Error(
-        `The value of ${value} is not included in the possible sequence provided by the step of ${
-          this.props.step
-        }.`
+        `The value of ${value} is not included in the possible sequence provided by the step of ${this.props.step}.`
       );
     }
     // Return the value if nothing fails
@@ -73,9 +67,7 @@ export class EuiRangeTrack extends Component {
     // Error out if there are too many ticks to render
     if (ticks.length > 20) {
       throw new Error(
-        `The number of ticks to render is too high (${
-          ticks.length
-        }), reduce the interval.`
+        `The number of ticks to render is too high (${ticks.length}), reduce the interval.`
       );
     }
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -531,7 +531,7 @@ export class EuiIcon extends Component<Props, State> {
           src={icon}
           className={classes}
           tabIndex={tabIndex}
-          {...rest as HTMLAttributes<HTMLImageElement>}
+          {...(rest as HTMLAttributes<HTMLImageElement>)}
         />
       );
     } else {

--- a/src/components/list_group/index.d.ts
+++ b/src/components/list_group/index.d.ts
@@ -1,7 +1,9 @@
+/* eslint-disable import/named */
 import {
   EuiButtonIconProps,
   EuiButtonPropsForButtonOrLink,
-} from '@elastic/eui'; // eslint-disable-line import/no-unresolved
+} from '@elastic/eui';
+/* eslint-enable import/named */
 import { IconType } from '../icon';
 import { CommonProps, ExclusiveUnion } from '../common';
 import {

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -85,12 +85,12 @@ export const EuiProgress: FunctionComponent<
         className={classes}
         max={max}
         value={value}
-        {...rest as ProgressHTMLAttributes<HTMLProgressElement>}
+        {...(rest as ProgressHTMLAttributes<HTMLProgressElement>)}
       />
     );
   } else {
     return (
-      <div className={classes} {...rest as HTMLAttributes<HTMLDivElement>} />
+      <div className={classes} {...(rest as HTMLAttributes<HTMLDivElement>)} />
     );
   }
 };

--- a/src/components/search_bar/query/default_syntax.js
+++ b/src/components/search_bar/query/default_syntax.js
@@ -261,9 +261,7 @@ const validateFieldValue = (
       schemaField.validate(value);
     } catch (e) {
       error(
-        `Invalid value \`${expression}\` set for field \`${field}\` - ${
-          e.message
-        }`,
+        `Invalid value \`${expression}\` set for field \`${field}\` - ${e.message}`,
         location
       );
     }

--- a/src/components/token/token_map.ts
+++ b/src/components/token/token_map.ts
@@ -61,7 +61,7 @@ export type EuiTokenMapType =
   | 'tokenModule';
 
 export const TOKEN_MAP: {
-  [mapType in EuiTokenMapType]: EuiTokenMapDisplayOptions
+  [mapType in EuiTokenMapType]: EuiTokenMapDisplayOptions;
 } = {
   tokenClass: {
     shape: 'circle',

--- a/src/services/popover/popover_positioning.ts
+++ b/src/services/popover/popover_positioning.ts
@@ -30,14 +30,14 @@ const relatedDimension: { [position in EuiPopoverPosition]: Dimension } = {
 };
 
 const dimensionPositionAttribute: {
-  [dimension in Dimension]: 'top' | 'left'
+  [dimension in Dimension]: 'top' | 'left';
 } = {
   height: 'top',
   width: 'left',
 };
 
 const positionComplements: {
-  [position in EuiPopoverPosition]: EuiPopoverPosition
+  [position in EuiPopoverPosition]: EuiPopoverPosition;
 } = {
   top: 'bottom',
   right: 'left',
@@ -48,7 +48,7 @@ const positionComplements: {
 // always resolving to top/left is taken advantage of by knowing they are the
 // minimum edges of the bounding box
 const positionSubstitutes: {
-  [position in EuiPopoverPosition]: 'left' | 'top'
+  [position in EuiPopoverPosition]: 'left' | 'top';
 } = {
   top: 'left',
   right: 'top',


### PR DESCRIPTION
I looked into the linting issues on this bracnh. I think it’s due to some upgraded `@typescript-eslint/*` packages, which I can only assume has happened due to adding a dependency on `@elastic/charts`.

Basically the `import/no-unresolved` ignores need to be `import/named` now. I used `/* eslint-disable import/named */` and `/* eslint-enable import/named */` in a few places, because that line error seems to be per-named-import, which makes sense.