### PR TITLE
TS updates

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -175,7 +175,7 @@ const EuiButtonDisplay = React.forwardRef<
         <Element
           className={classes}
           ref={ref as Ref<HTMLLabelElement>}
-          {...rest as HTMLAttributes<HTMLLabelElement>}>
+          {...rest}>
           {innerNode}
         </Element>
       );
@@ -184,7 +184,7 @@ const EuiButtonDisplay = React.forwardRef<
         <Element
           className={classes}
           ref={ref as Ref<HTMLAnchorElement>}
-          {...rest as HTMLAttributes<HTMLAnchorElement>}>
+          {...rest}>
           {innerNode}
         </Element>
       );
@@ -194,7 +194,7 @@ const EuiButtonDisplay = React.forwardRef<
           className={classes}
           disabled={isDisabled}
           ref={ref as Ref<HTMLButtonElement>}
-          {...rest as HTMLAttributes<HTMLButtonElement>}>
+          {...rest}>
           {innerNode}
         </Element>
       );

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -108,11 +108,10 @@ export interface EuiButtonDisplayProps extends EuiButtonProps {
 /**
  *
  * *INTERNAL ONLY* Component for displaying any element as a button
+ * EuiButton is largely responsible for providing relevant props
+ * and the logic for element-specific attributes
  */
-const EuiButtonDisplay = React.forwardRef<
-  HTMLAnchorElement | HTMLButtonElement | HTMLLabelElement,
-  EuiButtonDisplayProps
->(
+const EuiButtonDisplay = React.forwardRef<HTMLElement, EuiButtonDisplayProps>(
   (
     {
       children,
@@ -127,7 +126,7 @@ const EuiButtonDisplay = React.forwardRef<
       contentProps,
       textProps,
       fullWidth,
-      element: Element = 'button',
+      element = 'button',
       ...rest
     },
     ref
@@ -167,11 +166,14 @@ const EuiButtonDisplay = React.forwardRef<
       </EuiButtonContent>
     );
 
-    return (
-      // @ts-ignore difficult to verify `rest` applied to `Element`
-      <Element className={classes} ref={ref} {...rest}>
-        {innerNode}
-      </Element>
+    return React.createElement(
+      element,
+      {
+        className: classes,
+        ref,
+        ...rest,
+      },
+      innerNode
     );
   }
 );
@@ -209,12 +211,12 @@ export const EuiButton: FunctionComponent<Props> = ({
   ...rest
 }) => {
   const buttonIsDisabled = rest.isLoading || isDisabled || disabled;
-  // <Element> elements don't respect the `disabled` attribute. So if we're disabled, we'll just pretend
-  // this is a button and piggyback off its disabled styles.
   const element = href && !isDisabled ? 'a' : 'button';
 
   let elementProps = {};
+  // Props for all elements
   elementProps = { ...elementProps, isDisabled: buttonIsDisabled };
+  // Element-specific attributes
   if (element === 'button') {
     elementProps = { ...elementProps, disabled: buttonIsDisabled };
   }

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -170,11 +170,35 @@ const EuiButtonDisplay = React.forwardRef<
       </EuiButtonContent>
     );
 
-    return (
-      <Element className={classes} disabled={isDisabled} ref={ref} {...rest}>
-        {innerNode}
-      </Element>
-    );
+    if (Element === 'label') {
+      return (
+        <Element
+          className={classes}
+          ref={ref as Ref<HTMLLabelElement>}
+          {...rest as HTMLAttributes<HTMLLabelElement>}>
+          {innerNode}
+        </Element>
+      );
+    } else if (Element === 'a') {
+      return (
+        <Element
+          className={classes}
+          ref={ref as Ref<HTMLAnchorElement>}
+          {...rest as HTMLAttributes<HTMLAnchorElement>}>
+          {innerNode}
+        </Element>
+      );
+    } else {
+      return (
+        <Element
+          className={classes}
+          disabled={isDisabled}
+          ref={ref as Ref<HTMLButtonElement>}
+          {...rest as HTMLAttributes<HTMLButtonElement>}>
+          {innerNode}
+        </Element>
+      );
+    }
   }
 );
 
@@ -235,8 +259,8 @@ export const EuiButton: FunctionComponent<Props> = ({
       element={element}
       isDisabled={buttonIsDisabled}
       {...relObj}
-      ref={buttonRef as Ref<HTMLButtonElement & HTMLAnchorElement>}
-      {...rest as HTMLAttributes<HTMLAnchorElement | HTMLButtonElement>}
+      ref={buttonRef}
+      {...rest}
     />
   );
 };


### PR DESCRIPTION
`disabled` is not available on `a` and `label`, but it looks like the styling is handled. I didn't visually test, though