### PR TITLE
TS help for allowing extra data to be added to an `EuiSelectableOption` option

### DIFF
--- a/src-docs/src/views/selectable/props.tsx
+++ b/src-docs/src/views/selectable/props.tsx
@@ -5,7 +5,7 @@ import {
 } from '../../../../src/components/selectable';
 
 import {
-  EuiSelectableTemplateSitewideOptionProps,
+  EuiSelectableTemplateSitewideOption,
   EuiSelectableTemplateSitewideMetaData,
 } from '../../../../src/components/selectable/selectable_templates/selectable_template_sitewide_option';
 
@@ -17,7 +17,7 @@ export const EuiSelectableOptionsList: FunctionComponent<EuiSelectableOptionsLis
   <div />
 );
 
-export const Options: FunctionComponent<EuiSelectableTemplateSitewideOptionProps> = () => (
+export const Options: FunctionComponent<EuiSelectableTemplateSitewideOption> = () => (
   <div />
 );
 

--- a/src-docs/src/views/selectable/search.tsx
+++ b/src-docs/src/views/selectable/search.tsx
@@ -1,13 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import _ from 'lodash';
 
 import { EuiText } from '../../../../src/components/text';
 import { EuiBadge } from '../../../../src/components/badge';
 import { EuiSelectableTemplateSitewide } from '../../../../src/components/selectable';
-import { EuiSelectableTemplateSitewideOptionProps } from '../../../../src/components/selectable/selectable_templates/selectable_template_sitewide_option';
+import { EuiSelectableTemplateSitewideOption } from '../../../../src/components/selectable/selectable_templates/selectable_template_sitewide_option';
 import { EuiFlexGroup, EuiFlexItem } from '../../../../src/components/flex';
 import { EuiLink } from '../../../../src/components/link';
-import { EuiSelectableOption } from '../../../../src/components/selectable/selectable_option';
 
 export default () => {
   const [searchValue, setSearchValue] = useState('');
@@ -18,26 +16,31 @@ export default () => {
   /**
    * Timeout to simulate loading (only on key command+k)
    */
-  // @ts-ignore clear on every render in case it exists
+  let searchTimeout;
+  const startSearchTimeout = () => {
+    searchTimeout = setTimeout(() => {
+      // Simulate a remotely-executed search.
+      setLoading(false);
+    }, 400);
+  };
   clearTimeout(searchTimeout);
-  const searchTimeout = setTimeout(() => {
-    // Simulate a remotely-executed search.
-    setLoading(false);
-  }, 400);
+  startSearchTimeout();
 
   /**
    * Take the first 5 options and simulate recently viewed
    */
   const recents = searchData.slice(0, 5);
-  const recentsWithIcon = recents.map(recent => {
-    return {
-      ...recent,
-      icon: {
-        type: 'clock',
-        color: 'subdued',
-      },
-    };
-  });
+  const recentsWithIcon: EuiSelectableTemplateSitewideOption[] = recents.map(
+    recent => {
+      return {
+        ...recent,
+        icon: {
+          type: 'clock',
+          color: 'subdued',
+        },
+      };
+    }
+  );
 
   /**
    * Hook up the keyboard shortcut for command+k to initiate focus into search input
@@ -69,12 +72,9 @@ export default () => {
   /**
    * Do something with the selection based on the found option with `checked: on`
    */
-  const onChange = (updatedOptions: EuiSelectableOption[]) => {
-    const clickedItem = _.find(updatedOptions, {
-      checked: 'on',
-    });
+  const onChange = (updatedOptions: EuiSelectableTemplateSitewideOption[]) => {
+    const clickedItem = updatedOptions.find(option => option.checked === 'on');
     if (!clickedItem) return;
-    // @ts-ignore ??? Help
     if (clickedItem && clickedItem.url) console.log(clickedItem.url);
   };
 
@@ -83,14 +83,11 @@ export default () => {
       isLoading={isLoading}
       onChange={onChange}
       options={searchValueExists ? searchData : recentsWithIcon}
-      // @ts-ignore ???? Help
       searchProps={{
         append: '⌘K',
         onKeyUpCapture: onKeyUpCapture,
         className: 'customSearchClass',
-        inputRef: (ref: HTMLInputElement) => {
-          setSearchRef(ref);
-        },
+        inputRef: setSearchRef,
       }}
       listProps={{
         className: 'customListClass',
@@ -123,7 +120,7 @@ export default () => {
 /**
  * The options object
  */
-const searchData: EuiSelectableTemplateSitewideOptionProps[] = [
+const searchData: EuiSelectableTemplateSitewideOption[] = [
   {
     label: 'Welcome dashboards',
     avatar: {

--- a/src-docs/src/views/selectable/selectable_example.js
+++ b/src-docs/src/views/selectable/selectable_example.js
@@ -482,7 +482,7 @@ export const SelectableExample = {
             buttonContent={<small>Code snippet</small>}>
             <EuiSpacer size="xs" />
             <EuiCodeBlock language="ts" isCopyable paddingSize="s">
-              {`const options: EuiSelectableTemplateSitewideOptionProps[] = [
+              {`const options: EuiSelectableTemplateSitewideOption[] = [
   {
     label: 'Label',
     icon: {

--- a/src/components/selectable/index.ts
+++ b/src/components/selectable/index.ts
@@ -29,6 +29,6 @@ export { EuiSelectableSearch } from './selectable_search';
 export {
   EuiSelectableTemplateSitewide,
   EuiSelectableTemplateSitewideProps,
-  EuiSelectableTemplateSitewideOptionProps,
+  EuiSelectableTemplateSitewideOption,
   EuiSelectableTemplateSitewideMetaData,
 } from './selectable_templates';

--- a/src/components/selectable/selectable_option.tsx
+++ b/src/components/selectable/selectable_option.tsx
@@ -22,7 +22,7 @@ import { CommonProps, ExclusiveUnion } from '../common';
 
 export type EuiSelectableOptionCheckedType = 'on' | 'off' | undefined;
 
-export interface EuiSelectableOptionBase extends CommonProps {
+export type EuiSelectableOptionBase<T> = CommonProps & {
   /**
    * Visible label of option.
    * Must be unique across items if `key` is not supplied
@@ -59,24 +59,20 @@ export interface EuiSelectableOptionBase extends CommonProps {
    */
   append?: React.ReactNode;
   ref?: (optionIndex: number) => void;
-  /**
-   * The following allows for consumers to keep their data objects intact
-   * the same without needing to do key lookups when using `renderOption`
-   */
-  [key: string]: any;
-}
+} & T;
 
-export interface EuiSelectableGroupLabelOption
-  extends Omit<EuiSelectableOptionBase, 'isGroupLabel'>,
-    HTMLAttributes<HTMLDivElement> {
-  isGroupLabel: true;
-}
+export type EuiSelectableGroupLabelOption<T> = Omit<
+  EuiSelectableOptionBase<T>,
+  'isGroupLabel'
+> &
+  HTMLAttributes<HTMLDivElement> & {
+    isGroupLabel: true;
+  };
 
-export interface EuiSelectableLIOption
-  extends EuiSelectableOptionBase,
-    HTMLAttributes<HTMLLIElement> {}
+export type EuiSelectableLIOption<T> = EuiSelectableOptionBase<T> &
+  HTMLAttributes<HTMLLIElement>;
 
-export type EuiSelectableOption = ExclusiveUnion<
-  EuiSelectableGroupLabelOption,
-  EuiSelectableLIOption
+export type EuiSelectableOption<T = {}> = ExclusiveUnion<
+  EuiSelectableGroupLabelOption<T>,
+  EuiSelectableLIOption<T>
 >;

--- a/src/components/selectable/selectable_templates/index.ts
+++ b/src/components/selectable/selectable_templates/index.ts
@@ -23,7 +23,7 @@ export {
 } from './selectable_template_sitewide';
 
 export {
-  EuiSelectableTemplateSitewideOptionProps,
+  EuiSelectableTemplateSitewideOption,
   EuiSelectableTemplateSitewideMetaData,
   euiSelectableTemplateSitewideFormatOptions,
   euiSelectableTemplateSitewideRenderOptions,

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
@@ -22,9 +22,9 @@ import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 
 import { EuiSelectableTemplateSitewide } from './selectable_template_sitewide';
-import { EuiSelectableTemplateSitewideOptionProps } from './selectable_template_sitewide_option';
+import { EuiSelectableTemplateSitewideOption } from './selectable_template_sitewide_option';
 
-const options: EuiSelectableTemplateSitewideOptionProps[] = [
+const options: EuiSelectableTemplateSitewideOption[] = [
   {
     label: 'Basic data application',
     'data-test-subj': 'test-this',

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -31,7 +31,7 @@ import { useEuiI18n, EuiI18n } from '../../i18n';
 import { EuiSelectableMessage } from '../selectable_message';
 import { EuiLoadingSpinner } from '../../loading';
 import {
-  EuiSelectableTemplateSitewideOptionProps,
+  EuiSelectableTemplateSitewideOption,
   euiSelectableTemplateSitewideFormatOptions,
   euiSelectableTemplateSitewideRenderOptions,
 } from './selectable_template_sitewide_option';
@@ -41,7 +41,7 @@ export type EuiSelectableTemplateSitewideProps = Partial<EuiSelectableProps> & {
    * Extends the typical EuiSelectable #Options with the addition of pre-composed elements
    * such as `icon`, `avatar`and `meta`
    */
-  options: EuiSelectableTemplateSitewideOptionProps[];
+  options: EuiSelectableTemplateSitewideOption[];
   /**
    * Override some of the EuiPopover props housing the list.
    * The default width is `600`

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide_option.test.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide_option.test.tsx
@@ -20,12 +20,12 @@
 import { requiredProps } from '../../../test/required_props';
 
 import {
-  EuiSelectableTemplateSitewideOptionProps,
+  EuiSelectableTemplateSitewideOption,
   euiSelectableTemplateSitewideFormatOptions,
   euiSelectableTemplateSitewideRenderOptions,
 } from './selectable_template_sitewide_option';
 
-const options: EuiSelectableTemplateSitewideOptionProps[] = [
+const options: EuiSelectableTemplateSitewideOption[] = [
   {
     label: 'Basic data application',
     'data-test-subj': 'test-this',

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
@@ -49,7 +49,11 @@ export interface EuiSelectableTemplateSitewideMetaData extends CommonProps {
   highlightSearchString?: boolean;
 }
 
-export type EuiSelectableTemplateSitewideOptionProps = {
+/**
+ * The generic extension allows consumers to keep their data objects
+ * intact without needing to do key lookups when using `renderOption`
+ */
+export type EuiSelectableTemplateSitewideOption<T = { [key: string]: any }> = {
   /**
    * Displayed on the left (`prepend`).
    * Object of `EuiIconProps` for display of the solution/application's logo
@@ -64,12 +68,12 @@ export type EuiSelectableTemplateSitewideOptionProps = {
    * An array of inline #MetaData displayed beneath the label and separated by bullets.
    */
   meta?: EuiSelectableTemplateSitewideMetaData[];
-} & EuiSelectableOption;
+} & EuiSelectableOption<T>;
 
 export const euiSelectableTemplateSitewideFormatOptions = (
-  options: EuiSelectableTemplateSitewideOptionProps[]
+  options: EuiSelectableTemplateSitewideOption[]
 ) => {
-  return options.map((item: EuiSelectableTemplateSitewideOptionProps) => {
+  return options.map((item: EuiSelectableTemplateSitewideOption) => {
     return {
       key: item.label,
       label: item.label,
@@ -96,7 +100,7 @@ export const euiSelectableTemplateSitewideFormatOptions = (
 };
 
 export const euiSelectableTemplateSitewideRenderOptions = (
-  option: EuiSelectableOption,
+  option: EuiSelectableTemplateSitewideOption,
   searchValue: string
 ) => {
   return (


### PR DESCRIPTION
* Introduced a `EuiSelectableOption` generic, allowing for interface extensions
* Used `{ [key: string]: any }` generic extension in `EuiSelectableTemplateSitewideOption`
* Renamed `EuiSelectableTemplateSitewideOptionProps` to `EuiSelectableTemplateSitewideOption` because it made more sense to me 🤷‍♂️
* Changed `searchTimeout` to be TS-friendly