### PR TITLE
prevent format errors

### DIFF
--- a/src-docs/src/services/playground/playground.js
+++ b/src-docs/src/services/playground/playground.js
@@ -26,7 +26,15 @@ export default ({ config, setGhostBackground, playgroundClassName }) => {
       newCode = newCode.replace(/(\);)$/m, '');
     }
 
-    return format(newCode.trim(), ' '.repeat(4));
+    let formatted;
+    // TODO: Replace `html-format` with something better.
+    // Notably, something more jsx-friendly
+    try {
+      formatted = format(newCode.trim(), ' '.repeat(4));
+    } catch {
+      formatted = newCode.trim();
+    }
+    return formatted;
   };
 
   const Playground = () => {

--- a/src-docs/src/views/page/playground.js
+++ b/src-docs/src/views/page/playground.js
@@ -65,6 +65,7 @@ export default () => {
   });
 
   propsToUse.children = {
+    ...propsToUse.children,
     type: PropTypes.ReactNode,
     hidden: false,
   };


### PR DESCRIPTION
Fixes the `rightSideContede` error.
`tabs` issues still exists, but I'll let you decide how to handle the `children` dependency.