### PR TITLE
Panel with border only for amsterdam theme

### DIFF
--- a/src-docs/src/views/panel/panel_example.js
+++ b/src-docs/src/views/panel/panel_example.js
@@ -129,9 +129,11 @@ export const PanelExample = {
             title="Certain allowed combinations of shadow, border, and color depend on the current theme.">
             <p>
               For instance, only plain or transparent panels can have a border
-              and/or shadow. And the Amsterdam theme doesn&apos;t allow
-              combining the <EuiCode>hasBorder</EuiCode> option with{' '}
-              <EuiCode>hasShadow</EuiCode>.
+              and/or shadow. The Amsterdam theme doesn&apos;t allow combining
+              the <EuiCode>hasBorder</EuiCode> option with{' '}
+              <EuiCode>hasShadow</EuiCode>. The default theme only allows
+              removing the border if both <EuiCode>hasShadow</EuiCode> and{' '}
+              <EuiCode>hasBorder</EuiCode> are set to <EuiCode>false</EuiCode>.
             </p>
           </EuiCallOut>
         </>

--- a/src-docs/src/views/panel/panel_shadow.js
+++ b/src-docs/src/views/panel/panel_shadow.js
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { EuiPanel, EuiCode, EuiSpacer } from '../../../../src/components';
+import { ThemeContext } from '../../components';
 
 export default () => {
+  const themeContext = useContext(ThemeContext);
+  const isAmsterdamTheme = themeContext.theme.includes('amsterdam');
+
   return (
     <div>
       <EuiPanel hasShadow={false}>
@@ -11,11 +15,15 @@ export default () => {
 
       <EuiSpacer />
 
-      <EuiPanel hasBorder={true}>
-        <EuiCode>{'hasBorder={true}'}</EuiCode>
-      </EuiPanel>
-
-      <EuiSpacer />
+      {/* This example only works for the Amsterdam theme. The default theme has `hasBorder={true}` by default. */}
+      {isAmsterdamTheme && (
+        <>
+          <EuiPanel hasBorder={true}>
+            <EuiCode>{'hasBorder={true}'}</EuiCode>
+          </EuiPanel>
+          <EuiSpacer />
+        </>
+      )}
 
       <EuiPanel hasShadow={false} hasBorder={false}>
         <EuiCode>{'hasShadow={false} hasBorder={false}'}</EuiCode>


### PR DESCRIPTION
### Summary

Not sure this is the best way to improve the example but here's my idea. We only show the `hasBorder={true}` example for the Amsterdam theme. The default theme has `hasBorder={true}` by default so this example IMO doesn't make sense.

<img width="1968" alt="remove example@2x" src="https://user-images.githubusercontent.com/2750668/108357054-d847d300-71e4-11eb-9672-035623d960ba.png">

Also in the default theme, we can't remove the border unless the shadow is also set to `false`. So we can improve the callout to state that:

<img width="955" alt="Screenshot 2021-02-18 at 12 31 40" src="https://user-images.githubusercontent.com/2750668/108357396-4a201c80-71e5-11eb-98bb-9835fbc5f465.png">
