### PR TITLE
TypeScript

### DIFF
--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -789,7 +789,7 @@ function getPropTypesForNode(node, optional, state) {
           types.arrayExpression(
             node.properties.map(property =>
               types.stringLiteral(
-                property.key.name || property.key.name || property.key.value
+                property.key ? property.key.name || property.key.value : property.argument.name
               )
             )
           ),

--- a/src-docs/src/views/emotion/canopy.tsx
+++ b/src-docs/src/views/emotion/canopy.tsx
@@ -31,6 +31,7 @@ import {
   computed,
   buildTheme,
   EuiThemeModifications,
+  ComputedThemeShape,
 } from '../../../../src/services';
 import { EuiCodeBlock } from '../../../../src/components/code';
 import { EuiButton } from '../../../../src/components/button';
@@ -146,7 +147,7 @@ class Block extends React.Component<BlockProps> {
     );
   }
 }
-const BlockWithTheme = withEuiTheme(Block);
+const BlockWithTheme = withEuiTheme<BlockProps>(Block);
 
 export default () => {
   const [overrides, setOverrides] = React.useState({});
@@ -197,10 +198,7 @@ export default () => {
       mySize: number;
     };
   };
-  type ExtensionsComputed = {
-    colors: { myColor: string };
-    custom: { colors: { customColor: string }; mySize: number };
-  };
+  type ExtensionsComputed = ComputedThemeShape<ExtensionsUncomputed>;
 
   // Type (EuiThemeModifications<ExtensionsUncomputed>) only necessary if you want IDE autocomplete support here
   const extend: EuiThemeModifications<ExtensionsUncomputed> = {

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -58,6 +58,13 @@ export function keysOf<T, K extends keyof T>(obj: T): K[] {
   return Object.keys(obj) as K[];
 }
 
+/**
+ * Like `keyof typeof`, but for getting values instead of keys
+ * ValueOf<typeof {key1: 'value1', key2: 'value2'}>
+ * Results in `'value1' | 'value2'`
+ */
+export type ValueOf<T> = T[keyof T];
+
 export type PropsOf<C> = C extends SFC<infer SFCProps>
   ? SFCProps
   : C extends FunctionComponent<infer FunctionProps>

--- a/src/global_styling/variables/_borders.ts
+++ b/src/global_styling/variables/_borders.ts
@@ -19,7 +19,18 @@
 
 import { computed } from '../../services/theme/utils';
 
-export const border = {
+export interface EuiThemeBorder {
+  widthThin: string;
+  widthThick: string;
+  color: string;
+  radius: string;
+  radiusSmall: string;
+  thin: string;
+  thick: string;
+  editable: string;
+}
+
+export const border: EuiThemeBorder = {
   widthThin: '1px',
   widthThick: '2px',
   color: computed(([lightShade]) => lightShade, ['colors.lightShade']),

--- a/src/global_styling/variables/_colors.ts
+++ b/src/global_styling/variables/_colors.ts
@@ -18,7 +18,10 @@
  */
 
 import { computed } from '../../services/theme/utils';
-import { ColorModeSwitch } from '../../services/theme/types';
+import {
+  ColorModeSwitch,
+  StrictColorModeSwitch,
+} from '../../services/theme/types';
 import {
   makeDisabledContrastColor,
   makeHighContrastColor,
@@ -141,7 +144,7 @@ export const dark_colors: _EuiThemeBaseColors = {
   highlight: '#2E2D25',
 };
 
-export type EuiThemeColors = ColorModeSwitch<_EuiThemeBaseColors> &
+export type EuiThemeColors = StrictColorModeSwitch<_EuiThemeBaseColors> &
   _EuiThemeTextColors & {
     ghost: string;
     ink: string;

--- a/src/global_styling/variables/_colors.ts
+++ b/src/global_styling/variables/_colors.ts
@@ -18,6 +18,7 @@
  */
 
 import { computed } from '../../services/theme/utils';
+import { ColorModeSwitch } from '../../services/theme/types';
 import {
   makeDisabledContrastColor,
   makeHighContrastColor,
@@ -26,12 +27,9 @@ import {
 } from '../functions/_colors';
 
 export type _EuiThemeTextColors = {
-  /**
-   * TODO: Allow for `string | keys of LIGHT/DARK` instead of `any`
-   */
-  text: any;
-  title: any;
-  textSubdued: any;
+  text: ColorModeSwitch;
+  title: ColorModeSwitch;
+  textSubdued: ColorModeSwitch;
   textPrimary: string;
   textAccent: string;
   textSuccess: string;
@@ -143,13 +141,18 @@ export const dark_colors: _EuiThemeBaseColors = {
   highlight: '#2E2D25',
 };
 
-export type EuiThemeColors = _EuiThemeBaseColors &
+export type EuiThemeColors = ColorModeSwitch<_EuiThemeBaseColors> &
   _EuiThemeTextColors & {
-    disabled: any;
-    pageBackground: any;
+    ghost: string;
+    ink: string;
+    disabled: ColorModeSwitch;
+    pageBackground: ColorModeSwitch;
   };
 
 export const colors: EuiThemeColors = {
+  ghost: '#FFF',
+  ink: '#000',
+
   LIGHT: light_colors,
   DARK: dark_colors,
 

--- a/src/global_styling/variables/_size.ts
+++ b/src/global_styling/variables/_size.ts
@@ -30,7 +30,7 @@ export const sizeToPixel = (scale: number = 1) => (
 
 export type EuiThemeBase = number;
 
-export const base = 16;
+export const base: EuiThemeBase = 16;
 
 export interface EuiThemeSize {
   xs: string;

--- a/src/global_styling/variables/_size.ts
+++ b/src/global_styling/variables/_size.ts
@@ -28,9 +28,21 @@ export const sizeToPixel = (scale: number = 1) => (
   return `${base * scale}px`;
 };
 
+export type EuiThemeBase = number;
+
 export const base = 16;
 
-export const size = {
+export interface EuiThemeSize {
+  xs: string;
+  s: string;
+  m: string;
+  base: string;
+  l: string;
+  xl: string;
+  xxl: string;
+}
+
+export const size: EuiThemeSize = {
   xs: computed(sizeToPixel(0.25)),
   s: computed(sizeToPixel(0.5)),
   m: computed(sizeToPixel(0.75)),

--- a/src/global_styling/variables/_typography.ts
+++ b/src/global_styling/variables/_typography.ts
@@ -68,7 +68,15 @@ const font: EuiFont = {
 };
 
 // Font weights
-const fontWeight = {
+export interface EuiFontWeight {
+  // TODO: Make these CSSProperties['fontWeight']; ?
+  light: string;
+  regular: string;
+  medium: string;
+  semiBold: string;
+  bold: string;
+}
+const fontWeight: EuiFontWeight = {
   light: '300',
   regular: '400',
   medium: '500',
@@ -76,7 +84,7 @@ const fontWeight = {
   bold: '700',
 };
 
-type EuiFontSize = {
+export type EuiFontSize = {
   [mapType in EuiFontScale]: {
     fontSize: string;
     lineHeight: string;

--- a/src/global_styling/variables/_typography.ts
+++ b/src/global_styling/variables/_typography.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { CSSProperties } from 'react';
 import { keysOf } from '../../components/common';
 import { computed } from '../../services/theme/utils';
 import {
@@ -69,19 +70,18 @@ const font: EuiFont = {
 
 // Font weights
 export interface EuiFontWeight {
-  // TODO: Make these CSSProperties['fontWeight']; ?
-  light: string;
-  regular: string;
-  medium: string;
-  semiBold: string;
-  bold: string;
+  light: CSSProperties['fontWeight'];
+  regular: CSSProperties['fontWeight'];
+  medium: CSSProperties['fontWeight'];
+  semiBold: CSSProperties['fontWeight'];
+  bold: CSSProperties['fontWeight'];
 }
 const fontWeight: EuiFontWeight = {
-  light: '300',
-  regular: '400',
-  medium: '500',
-  semiBold: '600',
-  bold: '700',
+  light: 300,
+  regular: 400,
+  medium: 500,
+  semiBold: 600,
+  bold: 700,
 };
 
 export type EuiFontSize = {
@@ -90,7 +90,7 @@ export type EuiFontSize = {
     lineHeight: string;
   };
 };
-const fontSize = SCALES.reduce((acc, elem) => {
+const fontSize: EuiFontSize = SCALES.reduce((acc, elem) => {
   acc[elem] = {
     fontSize: computed(([base, scale]) => fontSizeFromScale(base, scale), [
       'base',

--- a/src/global_styling/variables/title.ts
+++ b/src/global_styling/variables/title.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { CSSProperties } from 'react';
 import { computed } from '../../services/theme/utils';
 import { EuiFontScale, SCALES } from './_typography';
 
@@ -24,7 +25,7 @@ export type EuiThemeTitle = {
   [size in EuiFontScale]: {
     color: string;
     fontSize: string;
-    fontWeight: string;
+    fontWeight: CSSProperties['fontWeight'];
     letterSpacing?: string;
     lineHeight: string;
   };

--- a/src/global_styling/variables/title.ts
+++ b/src/global_styling/variables/title.ts
@@ -18,59 +18,114 @@
  */
 
 import { computed } from '../../services/theme/utils';
+import { EuiFontScale, SCALES } from './_typography';
+
+export type EuiThemeTitle = {
+  [size in EuiFontScale]: {
+    color: string;
+    fontSize: string;
+    fontWeight: string;
+    letterSpacing?: string;
+    lineHeight: string;
+  };
+};
+
+const titlesPartial: {
+  [size in EuiFontScale]?: {
+    fontWeight: string;
+    letterSpacing: string;
+  };
+} = {
+  m: {
+    fontWeight: 'semiBold',
+    letterSpacing: '-.02em',
+  },
+  l: {
+    fontWeight: 'medium',
+    letterSpacing: '-.025em',
+  },
+  xl: {
+    fontWeight: 'light',
+    letterSpacing: '-.04em',
+  },
+  xxl: {
+    fontWeight: 'light',
+    letterSpacing: '-.03em',
+  },
+};
+
+export const title: EuiThemeTitle = SCALES.reduce((acc, size) => {
+  const partial = titlesPartial[size] || {
+    fontWeight: 'bold',
+    letterSpacing: undefined,
+  };
+  acc[size] = {
+    fontSize: computed(([{ fontSize }]) => fontSize, [`fontSize.${size}`]),
+    lineHeight: computed(([{ lineHeight }]) => lineHeight, [
+      `fontSize.${size}`,
+    ]),
+    color: computed(([color]) => color, ['colors.title']),
+    fontWeight: computed(([fontWeight]) => fontWeight, [
+      `fontWeight.${partial.fontWeight}`,
+    ]),
+    letterSpacing: partial.letterSpacing,
+  };
+  return acc;
+}, {} as EuiThemeTitle);
 
 // Titles map
 // TODO --> MOVE TO COMPONENTS and rename to `title` when out of `colors` key
 // Lists all the properties per EuiTitle size that then gets looped through to create the selectors.
 // The map allows for tokenization and easier customization per theme, otherwise you'd have to override the selectors themselves
-export const title = {
-  xxxs: {
-    color: computed(([color]) => color, ['colors.title']),
-    fontSize: computed(([fontSize]) => fontSize.fontSize, ['fontSize.xxxs']),
-    lineHeight: computed(([lineHeight]) => lineHeight.lineHeight, [
-      'fontSize.xxxs',
-    ]),
-    fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.bold']),
-  },
-  xxs: {
-    color: computed(([color]) => color, ['colors.title']),
-    // HELP: Spreading doesn't work
-    // ...computed(([fontSize]) => fontSize, [`fontSize.xxs`]),
-    fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.bold']),
-  },
-  xs: {
-    color: computed(([color]) => color, ['colors.title']),
-    fontSize: computed(([fontSize]) => fontSize, ['fontSize.xs']),
-    fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.bold']),
-  },
-  s: {
-    color: computed(([color]) => color, ['colors.title']),
-    fontSize: computed(([fontSize]) => fontSize, ['fontSize.s']),
-    fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.bold']),
-  },
-  m: {
-    color: computed(([color]) => color, ['colors.title']),
-    fontSize: computed(([fontSize]) => fontSize, ['fontSize.m']),
-    fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.semiBold']),
-    letterSpacing: '-.02em',
-  },
-  l: {
-    color: computed(([color]) => color, ['colors.title']),
-    fontSize: computed(([fontSize]) => fontSize, ['fontSize.l']),
-    fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.medium']),
-    letterSpacing: '-.025em',
-  },
-  xl: {
-    color: computed(([color]) => color, ['colors.title']),
-    fontSize: computed(([fontSize]) => fontSize, ['fontSize.xl']),
-    fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.light']),
-    letterSpacing: '-.04em',
-  },
-  xxl: {
-    color: computed(([color]) => color, ['colors.title']),
-    fontSize: computed(([font]) => font.fontSize, ['fontSize.xxl']),
-    lineHeight: computed(([font]) => font.lineHeight, ['fontSize.xxl']),
-    fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.light']),
-    letterSpacing: '-.03em',
-  },
-};
+
+// export const title: EuiThemeTitle = {
+//   xxxs: {
+//     color: computed(([color]) => color, ['colors.title']),
+//     fontSize: computed(([fontSize]) => fontSize.fontSize, ['fontSize.xxxs']),
+//     lineHeight: computed(([lineHeight]) => lineHeight.lineHeight, [
+//       'fontSize.xxxs',
+//     ]),
+//     fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.bold']),
+//   },
+//   xxs: {
+//     color: computed(([color]) => color, ['colors.title']),
+//     // HELP: Spreading doesn't work
+//     // ...computed(([fontSize]) => fontSize, [`fontSize.xxs`]),
+//     fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.bold']),
+//   },
+//   xs: {
+//     color: computed(([color]) => color, ['colors.title']),
+//     fontSize: computed(([fontSize]) => fontSize, ['fontSize.xs']),
+//     fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.bold']),
+//   },
+//   s: {
+//     color: computed(([color]) => color, ['colors.title']),
+//     fontSize: computed(([fontSize]) => fontSize, ['fontSize.s']),
+//     fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.bold']),
+//   },
+//   m: {
+//     color: computed(([color]) => color, ['colors.title']),
+//     fontSize: computed(([fontSize]) => fontSize, ['fontSize.m']),
+//     fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.semiBold']),
+//     letterSpacing: '-.02em',
+//   },
+//   l: {
+//     color: computed(([color]) => color, ['colors.title']),
+//     fontSize: computed(([fontSize]) => fontSize, ['fontSize.l']),
+//     fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.medium']),
+//     letterSpacing: '-.025em',
+//   },
+//   xl: {
+//     color: computed(([color]) => color, ['colors.title']),
+//     fontSize: computed(([fontSize]) => fontSize, ['fontSize.xl']),
+//     fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.light']),
+//     letterSpacing: '-.04em',
+//   },
+//   xxl: {
+//     color: computed(([color]) => color, ['colors.title']),
+//     fontSize: computed(([font]) => font.fontSize, ['fontSize.xxl']),
+//     lineHeight: computed(([font]) => font.lineHeight, ['fontSize.xxl']),
+//     fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.light']),
+//     letterSpacing: '-.03em',
+//   },
+// };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -140,7 +140,7 @@ export {
   mergeDeep,
   setOn,
   Computed,
-  EuiThemeColor,
+  ComputedThemeShape,
   EuiThemeColorMode,
   EuiThemeComputed,
   EuiThemeModifications,

--- a/src/services/theme/index.ts
+++ b/src/services/theme/index.ts
@@ -37,7 +37,7 @@ export {
   Computed,
 } from './utils';
 export {
-  EuiThemeColor,
+  ComputedThemeShape,
   EuiThemeColorMode,
   EuiThemeComputed,
   EuiThemeModifications,

--- a/src/services/theme/types.ts
+++ b/src/services/theme/types.ts
@@ -17,8 +17,23 @@
  * under the License.
  */
 
-import { RecursiveOmit, RecursivePartial } from '../../components/common';
-import { euiThemeDefault } from '../../themes/eui/theme';
+import {
+  RecursiveOmit,
+  RecursivePartial,
+  ValueOf,
+} from '../../components/common';
+import { EuiThemeBorder } from '../../global_styling/variables/_borders';
+import { EuiThemeColors } from '../../global_styling/variables/_colors';
+import {
+  EuiThemeBase,
+  EuiThemeSize,
+} from '../../global_styling/variables/_size';
+import { EuiThemeTitle } from '../../global_styling/variables/title';
+import {
+  EuiFont,
+  EuiFontSize,
+  EuiFontWeight,
+} from '../../global_styling/variables/_typography';
 
 export const COLOR_MODES_STANDARD = {
   light: 'LIGHT',
@@ -27,15 +42,27 @@ export const COLOR_MODES_STANDARD = {
 export const COLOR_MODES_INVERSE = 'INVERSE' as const;
 
 type EuiThemeColorModeInverse = typeof COLOR_MODES_INVERSE;
-type EuiThemeColorModeStandard = keyof typeof COLOR_MODES_STANDARD;
+type EuiThemeColorModeStandard = ValueOf<typeof COLOR_MODES_STANDARD>;
 export type EuiThemeColorMode =
   | string
   | EuiThemeColorModeStandard
   | EuiThemeColorModeInverse;
 
-// TODO: Make static interface
-export type EuiThemeShape = typeof euiThemeDefault;
-export type EuiThemeColor = EuiThemeShape['colors']['LIGHT'];
+export type ColorModeSwitch<T = string> = {
+  [key in EuiThemeColorModeStandard]: T;
+};
+
+export type EuiThemeShape = {
+  colors: EuiThemeColors;
+  base: EuiThemeBase;
+  size: EuiThemeSize;
+  font: EuiFont;
+  fontSize: EuiFontSize;
+  fontWeight: EuiFontWeight;
+  border: EuiThemeBorder;
+  title: EuiThemeTitle;
+};
+export type EuiThemeColor = EuiThemeColors['LIGHT'];
 
 export type EuiThemeSystem<T = {}> = {
   root: EuiThemeShape & T;

--- a/src/services/theme/types.ts
+++ b/src/services/theme/types.ts
@@ -44,7 +44,13 @@ export type EuiThemeColorMode =
   | EuiThemeColorModeStandard
   | EuiThemeColorModeInverse;
 
-export type ColorModeSwitch<T = string> = {
+export type ColorModeSwitch<T = string> =
+  | {
+      [key in EuiThemeColorModeStandard]: T;
+    }
+  | T;
+
+export type StrictColorModeSwitch<T = string> = {
   [key in EuiThemeColorModeStandard]: T;
 };
 
@@ -76,8 +82,11 @@ export type ComputedThemeShape<
       ? X
       : {
           [K in keyof (X &
-            Exclude<T, keyof X | keyof ColorModeSwitch>)]: ComputedThemeShape<
-            (X & Exclude<T, keyof X | keyof ColorModeSwitch>)[K],
+            Exclude<
+              T,
+              keyof X | keyof StrictColorModeSwitch
+            >)]: ComputedThemeShape<
+            (X & Exclude<T, keyof X | keyof StrictColorModeSwitch>)[K],
             P
           >;
         }

--- a/src/services/theme/utils.test.ts
+++ b/src/services/theme/utils.test.ts
@@ -31,31 +31,25 @@ import {
 
 describe('isInverseColorMode', () => {
   it("true only if 'inverse'", () => {
-    expect(isInverseColorMode('light')).toBe(false);
-    expect(isInverseColorMode('dark')).toBe(false);
+    expect(isInverseColorMode('LIGHT')).toBe(false);
+    expect(isInverseColorMode('DARK')).toBe(false);
     expect(isInverseColorMode('custom')).toBe(false);
     expect(isInverseColorMode()).toBe(false);
-    expect(isInverseColorMode('inverse')).toBe(true);
+    expect(isInverseColorMode('INVERSE')).toBe(true);
   });
 });
 
 describe('getColorMode', () => {
-  it("defaults to 'light'", () => {
-    expect(getColorMode()).toEqual('light');
+  it("defaults to 'LIGHT'", () => {
+    expect(getColorMode()).toEqual('LIGHT');
   });
   it('uses `parentMode` as fallback', () => {
-    expect(getColorMode(undefined, 'dark')).toEqual('dark');
+    expect(getColorMode(undefined, 'DARK')).toEqual('DARK');
   });
-  it("understands 'inverse'", () => {
-    expect(getColorMode('inverse', 'dark')).toEqual('light');
-    expect(getColorMode('inverse', 'light')).toEqual('dark');
-    expect(getColorMode('inverse')).toEqual('light');
-  });
-  it('respects custom modes', () => {
-    expect(getColorMode('custom')).toEqual('custom');
-    expect(getColorMode('custom', 'light')).toEqual('custom');
-    expect(getColorMode(undefined, 'custom')).toEqual('custom');
-    expect(getColorMode('light', 'custom')).toEqual('light');
+  it("understands 'INVERSE'", () => {
+    expect(getColorMode('INVERSE', 'DARK')).toEqual('LIGHT');
+    expect(getColorMode('INVERSE', 'LIGHT')).toEqual('DARK');
+    expect(getColorMode('INVERSE')).toEqual('LIGHT');
   });
 });
 
@@ -73,9 +67,8 @@ describe('getOn', () => {
       },
     },
     colors: {
-      light: { primary: '#000' },
-      dark: { primary: '#FFF' },
-      custom: { primary: '#333' },
+      LIGHT: { primary: '#000' },
+      DARK: { primary: '#FFF' },
     },
   };
   it('gets values at the given path', () => {
@@ -91,9 +84,8 @@ describe('getOn', () => {
     expect(getOn(obj, 'other.thing.func', '')).toBeInstanceOf(Function);
   });
   it('can shortcut color modes', () => {
-    expect(getOn(obj, 'colors.primary', 'light')).toEqual('#000');
-    expect(getOn(obj, 'colors.primary', 'dark')).toEqual('#FFF');
-    expect(getOn(obj, 'colors.primary', 'custom')).toEqual('#333');
+    expect(getOn(obj, 'colors.primary', 'LIGHT')).toEqual('#000');
+    expect(getOn(obj, 'colors.primary', 'DARK')).toEqual('#FFF');
   });
   it('will not error', () => {
     expect(getOn(obj, 'nope', '')).toBe(undefined);
@@ -164,11 +156,11 @@ describe('computed', () => {
 const theme = buildTheme(
   {
     colors: {
-      light: {
+      LIGHT: {
         primary: '#000',
         secondary: computed(([primary]) => `${primary}000`, ['colors.primary']),
       },
-      dark: {
+      DARK: {
         primary: '#FFF',
         secondary: computed((theme) => `${theme.colors.primary}FFF`),
       },
@@ -181,14 +173,14 @@ const theme = buildTheme(
 );
 describe('getComputed', () => {
   it('computes all values and returns only the current color mode', () => {
-    // @ts-ignore intentionally not using a full EUI theme definition
-    expect(getComputed(theme, {}, 'light')).toEqual({
+    // @ts-expect-error intentionally not using a full EUI theme definition
+    expect(getComputed(theme, {}, 'LIGHT')).toEqual({
       colors: { primary: '#000', secondary: '#000000' },
       sizes: { small: 8 },
       themeName: 'minimal',
     });
-    // @ts-ignore intentionally not using a full EUI theme definition
-    expect(getComputed(theme, {}, 'dark')).toEqual({
+    // @ts-expect-error intentionally not using a full EUI theme definition
+    expect(getComputed(theme, {}, 'DARK')).toEqual({
       colors: { primary: '#FFF', secondary: '#FFFFFF' },
       sizes: { small: 8 },
       themeName: 'minimal',
@@ -196,8 +188,8 @@ describe('getComputed', () => {
   });
   it('respects simple overrides', () => {
     expect(
-      // @ts-ignore intentionally not using a full EUI theme definition
-      getComputed(theme, buildTheme({ sizes: { small: 4 } }, ''), 'light')
+      // @ts-expect-error intentionally not using a full EUI theme definition
+      getComputed(theme, buildTheme({ sizes: { small: 4 } }, ''), 'LIGHT')
     ).toEqual({
       colors: { primary: '#000', secondary: '#000000' },
       sizes: { small: 4 },
@@ -207,10 +199,10 @@ describe('getComputed', () => {
   it('respects overrides in computation', () => {
     expect(
       getComputed(
-        // @ts-ignore intentionally not using a full EUI theme definition
+        // @ts-expect-error intentionally not using a full EUI theme definition
         theme,
-        buildTheme({ colors: { light: { primary: '#CCC' } } }, ''),
-        'light'
+        buildTheme({ colors: { LIGHT: { primary: '#CCC' } } }, ''),
+        'LIGHT'
       )
     ).toEqual({
       colors: { primary: '#CCC', secondary: '#CCC000' },
@@ -221,10 +213,10 @@ describe('getComputed', () => {
   it('respects property extensions', () => {
     expect(
       getComputed(
-        // @ts-ignore intentionally not using a full EUI theme definition
+        // @ts-expect-error intentionally not using a full EUI theme definition
         theme,
-        buildTheme({ colors: { light: { tertiary: '#333' } } }, ''),
-        'light'
+        buildTheme({ colors: { LIGHT: { tertiary: '#333' } } }, ''),
+        'LIGHT'
       )
     ).toEqual({
       colors: { primary: '#000', secondary: '#000000', tertiary: '#333' },
@@ -235,10 +227,10 @@ describe('getComputed', () => {
   it('respects section extensions', () => {
     expect(
       getComputed(
-        // @ts-ignore intentionally not using a full EUI theme definition
+        // @ts-expect-error intentionally not using a full EUI theme definition
         theme,
         buildTheme({ custom: { myProp: '#333' } }, ''),
-        'light'
+        'LIGHT'
       )
     ).toEqual({
       colors: { primary: '#000', secondary: '#000000' },
@@ -250,12 +242,12 @@ describe('getComputed', () => {
   it('respects extensions in computation', () => {
     expect(
       getComputed(
-        // @ts-ignore intentionally not using a full EUI theme definition
+        // @ts-expect-error intentionally not using a full EUI theme definition
         theme,
         buildTheme(
           {
             colors: {
-              light: {
+              LIGHT: {
                 tertiary: computed(([primary]) => `${primary}333`, [
                   'colors.primary',
                 ]),
@@ -264,7 +256,7 @@ describe('getComputed', () => {
           },
           ''
         ),
-        'light'
+        'LIGHT'
       )
     ).toEqual({
       colors: { primary: '#000', secondary: '#000000', tertiary: '#000333' },

--- a/src/themes/eui-amsterdam/global_styling/variables/_borders.ts
+++ b/src/themes/eui-amsterdam/global_styling/variables/_borders.ts
@@ -18,9 +18,12 @@
  */
 
 import { computed } from '../../../../services/theme/utils';
-import { border } from '../../../../global_styling/variables/_borders';
+import {
+  border,
+  EuiThemeBorder,
+} from '../../../../global_styling/variables/_borders';
 
-export const border_ams = {
+export const border_ams: EuiThemeBorder = {
   ...border,
   // TODO: Decide if we should always calculate from `base`
   radius: computed(([base]) => `${base * 0.375}px`, ['base']),

--- a/src/themes/eui-amsterdam/global_styling/variables/_colors.ts
+++ b/src/themes/eui-amsterdam/global_styling/variables/_colors.ts
@@ -20,15 +20,43 @@
 import { computed } from '../../../../services/theme/utils';
 import {
   makeHighContrastColor,
+  makeDisabledContrastColor,
   shade,
   tint,
 } from '../../../../global_styling/functions/_colors';
-import { EuiThemeColors } from '../../../../global_styling/variables/_colors';
+import {
+  EuiThemeColors,
+  _EuiThemeTextColors,
+} from '../../../../global_styling/variables/_colors';
+
+const textVariants: _EuiThemeTextColors = {
+  text: computed(([darkestShade]) => darkestShade, ['colors.darkestShade']),
+  title: computed(([text]) => shade(text, 0.5), ['colors.text']),
+
+  textSubdued: computed(([darkShade]) => makeHighContrastColor(darkShade), [
+    'colors.darkShade',
+  ]),
+
+  textPrimary: computed((theme) => makeHighContrastColor(theme.colors.primary)),
+  textAccent: computed(([accent]) => makeHighContrastColor(accent), [
+    'colors.accent',
+  ]),
+  textSuccess: computed(([success]) => makeHighContrastColor(success), [
+    'colors.success',
+  ]),
+  textWarning: computed(([warning]) => makeHighContrastColor(warning), [
+    'colors.warning',
+  ]),
+  textDanger: computed(([danger]) => makeHighContrastColor(danger), [
+    'colors.danger',
+  ]),
+  textDisabled: computed(([disabled]) => makeDisabledContrastColor(disabled), [
+    'colors.disabled',
+  ]),
+  link: computed(([textPrimary]) => textPrimary, ['colors.textPrimary']),
+};
 
 const light_colors_ams = {
-  ghost: '#FFF',
-  ink: '#000',
-
   // Brand
   primary: '#07C',
   accent: '#F04E98',
@@ -47,26 +75,10 @@ const light_colors_ams = {
   darkestShade: '#343741',
   fullShade: '#000',
 
-  // Backgrounds
-  pageBackground: computed(([lightestShade]) => tint(lightestShade, 0.5), [
-    'colors.lightestShade',
-  ]),
   highlight: computed(([warning]) => tint(warning, 0.9), ['colors.warning']),
-
-  // Every color below must be based mathematically on the set above and in a particular order.
-  text: computed(([darkestShade]) => darkestShade, ['colors.darkestShade']),
-  title: computed(([text]) => shade(text, 0.5), ['colors.text']),
-  disabled: '#ABB4C4',
-
-  textSubdued: computed(([darkShade]) => makeHighContrastColor(darkShade), [
-    'colors.darkShade',
-  ]),
 };
 
 const dark_colors_ams = {
-  ghost: '#FFF',
-  ink: '#000',
-
   // Brand
   primary: '#36A2EF',
   accent: '#F68FBE',
@@ -85,24 +97,29 @@ const dark_colors_ams = {
   darkestShade: '#D4DAE5',
   fullShade: '#FFF',
 
-  // Backgrounds
-  pageBackground: computed(([lightestShade]) => shade(lightestShade, 0.3), [
-    'colors.lightestShade',
-  ]),
   highlight: '#2E2D25',
-
-  // Every color below must be based mathematically on the set above and in a particular order.
-  text: '#DFE5EF',
-  title: computed(([text]) => text, ['colors.text']),
-  disabled: '#515761',
-
-  textSubdued: computed(([mediumShade]) => makeHighContrastColor(mediumShade), [
-    'colors.mediumShade',
-  ]),
 };
 
-// TODO: Type this correctly when complete
-export const colors_ams = ({
+export const colors_ams: EuiThemeColors = {
+  ghost: '#FFF',
+  ink: '#000',
+
   LIGHT: light_colors_ams,
   DARK: dark_colors_ams,
-} as unknown) as EuiThemeColors;
+
+  pageBackground: {
+    LIGHT: computed(([lightestShade]) => tint(lightestShade, 0.5), [
+      'colors.lightestShade',
+    ]),
+    DARK: computed(([lightestShade]) => shade(lightestShade, 0.3), [
+      'colors.lightestShade',
+    ]),
+  },
+
+  disabled: {
+    LIGHT: '#ABB4C4',
+    DARK: '#515761',
+  },
+
+  ...textVariants,
+};

--- a/src/themes/eui-amsterdam/global_styling/variables/_colors.ts
+++ b/src/themes/eui-amsterdam/global_styling/variables/_colors.ts
@@ -23,10 +23,11 @@ import {
   shade,
   tint,
 } from '../../../../global_styling/functions/_colors';
-import { poles } from '../../../../global_styling/variables/_colors';
+import { EuiThemeColors } from '../../../../global_styling/variables/_colors';
 
-export const light_colors_ams = {
-  ...poles,
+const light_colors_ams = {
+  ghost: '#FFF',
+  ink: '#000',
 
   // Brand
   primary: '#07C',
@@ -62,8 +63,9 @@ export const light_colors_ams = {
   ]),
 };
 
-export const dark_colors_ams = {
-  ...poles,
+const dark_colors_ams = {
+  ghost: '#FFF',
+  ink: '#000',
 
   // Brand
   primary: '#36A2EF',
@@ -98,3 +100,9 @@ export const dark_colors_ams = {
     'colors.mediumShade',
   ]),
 };
+
+// TODO: Type this correctly when complete
+export const colors_ams = ({
+  LIGHT: light_colors_ams,
+  DARK: dark_colors_ams,
+} as unknown) as EuiThemeColors;

--- a/src/themes/eui-amsterdam/global_styling/variables/_typography.ts
+++ b/src/themes/eui-amsterdam/global_styling/variables/_typography.ts
@@ -17,9 +17,11 @@
  * under the License.
  */
 
-import fontBase from '../../../../global_styling/variables/_typography';
+import fontBase, {
+  EuiFont,
+} from '../../../../global_styling/variables/_typography';
 
-const font = {
+const font: EuiFont = {
   ...fontBase.font,
   family:
     "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",

--- a/src/themes/eui-amsterdam/global_styling/variables/title.ts
+++ b/src/themes/eui-amsterdam/global_styling/variables/title.ts
@@ -17,24 +17,20 @@
  * under the License.
  */
 
-import { title } from '../../../../global_styling/variables/title';
 import {
-  EuiFontScale,
-  SCALES,
-} from '../../../../global_styling/variables/_typography';
+  title,
+  EuiThemeTitle,
+} from '../../../../global_styling/variables/title';
+import { SCALES } from '../../../../global_styling/variables/_typography';
 import { computed } from '../../../../services/theme/utils';
 
 // For Amsterdam, change all font-weights to bold and remover letter-spacing
 
-// @ts-ignore TS help
-export const title_ams: {
-  [mapType in EuiFontScale]: string;
-} = SCALES.reduce((acc, elem) => {
-  // @ts-ignore TS help
+export const title_ams: EuiThemeTitle = SCALES.reduce((acc, elem) => {
   acc[elem] = {
     ...title[elem],
     fontWeight: computed(([fontWeight]) => fontWeight, ['fontWeight.bold']),
     letterSpacing: undefined,
   };
   return acc;
-}, {});
+}, {} as EuiThemeTitle);

--- a/src/themes/eui-amsterdam/theme.ts
+++ b/src/themes/eui-amsterdam/theme.ts
@@ -17,21 +17,15 @@
  * under the License.
  */
 
-import { buildTheme } from '../../services/theme';
+import { buildTheme, EuiThemeShape } from '../../services/theme';
 import { base, size } from '../../global_styling/variables/_size';
-import {
-  light_colors_ams,
-  dark_colors_ams,
-} from './global_styling/variables/_colors';
+import { colors_ams } from './global_styling/variables/_colors';
 import fonts_ams from './global_styling/variables/_typography';
 import { border_ams } from './global_styling/variables/_borders';
 import { title_ams } from './global_styling/variables/title';
 
-export const euiThemeAmsterdam = {
-  colors: {
-    LIGHT: light_colors_ams,
-    DARK: dark_colors_ams,
-  },
+export const euiThemeAmsterdam: EuiThemeShape = {
+  colors: colors_ams,
   base,
   size,
   ...fonts_ams,

--- a/src/themes/eui/theme.ts
+++ b/src/themes/eui/theme.ts
@@ -18,13 +18,14 @@
  */
 
 import { buildTheme } from '../../services/theme/utils';
+import { EuiThemeShape } from '../../services/theme/types';
 import { colors } from '../../global_styling/variables/_colors';
 import { base, size } from '../../global_styling/variables/_size';
 import fonts from '../../global_styling/variables/_typography';
 import { border } from '../../global_styling/variables/_borders';
 import { title } from '../../global_styling/variables/title';
 
-export const euiThemeDefault = {
+export const euiThemeDefault: EuiThemeShape = {
   colors,
   base,
   size,


### PR DESCRIPTION
To do:
* Come up with a better name than `ColorModeSwitch`?
* ~Make `EuiComputedTheme` work again~
* ~Discuss how this affects custom color modes~ See https://github.com/elastic/eui/pull/4643#issuecomment-811164296

~There are a few colors missing from the computed theme type. It's definitely fixable but depends on what shape the colors section takes.~ Fixed with _more_ TypeScript